### PR TITLE
gstreamer-plugins-bad: rework PACKAGECONFIG setting

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,11 +1,8 @@
-python () {
-    if 'tegra' not in d.getVar('MACHINEOVERRIDES').split(':'):
-        return
+def faad2_license_ok(d):
     if bb.data.inherits_class('license', d):
         license_allowedlist = (d.getVar('LICENSE_FLAGS_WHITELIST') or '').split()
-        if 'commercial' not in license_allowedlist and 'commercial_faad2' not in license_allowedlist:
-            return
+        return 'commercial' in license_allowedlist or 'commercial_faad2' in license_allowedlist
+    return True
 
-    d.appendVar('PACKAGECONFIG', ' faad')
-    d.setVar('PACKAGE_ARCH', '${TEGRA_PKGARCH}')
-}
+PACKAGECONFIG_append_tegra = "${@' faad' if faad2_license_ok(d) else ''}"
+PACKAGE_ARCH_tegra = "${@'${TEGRA_PKGARCH}' if faad2_license_ok(d) else '${TUNE_PKGARCH}'}"


### PR DESCRIPTION
Modifying PACKAGECONFIG via anonymous python doesn't work
when the function is executed after the anonymous python
functions in base.bbclass, so rework the changes to append
or modify variables instead.

Signed-off-by: Matt Madison <matt@madison.systems>