### PR TITLE
Deepstream-6.0 recipe for master

### DIFF
--- a/recipes-connectivity/openssl/files/environment.d-openssl.sh
+++ b/recipes-connectivity/openssl/files/environment.d-openssl.sh
@@ -1,0 +1,1 @@
+export OPENSSL111_CONF="$OECORE_NATIVE_SYSROOT/usr/lib/ssl/openssl.cnf"

--- a/recipes-connectivity/openssl/openssl111/0001-buildinfo-strip-sysroot-and-debug-prefix-map-from-co.patch
+++ b/recipes-connectivity/openssl/openssl111/0001-buildinfo-strip-sysroot-and-debug-prefix-map-from-co.patch
@@ -1,0 +1,76 @@
+From 3e1d00481093e10775eaf69d619c45b32a4aa7dc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Martin=20Hundeb=C3=B8ll?= <martin@geanix.com>
+Date: Tue, 6 Nov 2018 14:50:47 +0100
+Subject: [PATCH] buildinfo: strip sysroot and debug-prefix-map from compiler
+ info
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The openssl build system generates buildinf.h containing the full
+compiler command line used to compile objects. This breaks
+reproducibility, as the compile command is baked into libcrypto, where
+it is used when running `openssl version -f`.
+
+Add stripped build variables for the compiler and cflags lines, and use
+those when generating buildinfo.h.
+
+This is based on a similar patch for older openssl versions:
+https://patchwork.openembedded.org/patch/147229/
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Martin Hundebøll <martin@geanix.com>
+
+
+Update to fix buildpaths qa issue for '-fmacro-prefix-map'.
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+---
+ Configurations/unix-Makefile.tmpl | 10 +++++++++-
+ crypto/build.info                 |  2 +-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
+index 16af4d2087..54c162784c 100644
+--- a/Configurations/unix-Makefile.tmpl
++++ b/Configurations/unix-Makefile.tmpl
+@@ -317,13 +317,22 @@ BIN_LDFLAGS={- join(' ', $target{bin_lflags} || (),
+                          '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
+ BIN_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
+ 
+-# CPPFLAGS_Q is used for one thing only: to build up buildinf.h
++# *_Q variables are used for one thing only: to build up buildinf.h
+ CPPFLAGS_Q={- $cppflags1 =~ s|([\\"])|\\$1|g;
+               $cppflags2 =~ s|([\\"])|\\$1|g;
+               $lib_cppflags =~ s|([\\"])|\\$1|g;
+               join(' ', $lib_cppflags || (), $cppflags2 || (),
+                         $cppflags1 || ()) -}
+ 
++CFLAGS_Q={- for (@{$config{CFLAGS}}) {
++              s|-fdebug-prefix-map=[^ ]+|-fdebug-prefix-map=|g;
++              s|-fmacro-prefix-map=[^ ]+|-fmacro-prefix-map=|g;
++            }
++            join(' ', @{$config{CFLAGS}}) -}
++
++CC_Q={- $config{CC} =~ s|--sysroot=[^ ]+|--sysroot=recipe-sysroot|g;
++        join(' ', $config{CC}) -}
++
+ PERLASM_SCHEME= {- $target{perlasm_scheme} -}
+ 
+ # For x86 assembler: Set PROCESSOR to 386 if you want to support
+diff --git a/crypto/build.info b/crypto/build.info
+index b515b7318e..8c9cee2a09 100644
+--- a/crypto/build.info
++++ b/crypto/build.info
+@@ -10,7 +10,7 @@ EXTRA=  ../ms/uplink-x86.pl ../ms/uplink.c ../ms/applink.c \
+         ppccpuid.pl pariscid.pl alphacpuid.pl arm64cpuid.pl armv4cpuid.pl
+ 
+ DEPEND[cversion.o]=buildinf.h
+-GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC) $(LIB_CFLAGS) $(CPPFLAGS_Q)" "$(PLATFORM)"
++GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC_Q) $(CFLAGS_Q) $(CPPFLAGS_Q)" "$(PLATFORM)"
+ DEPEND[buildinf.h]=../configdata.pm
+ 
+ GENERATE[uplink-x86.s]=../ms/uplink-x86.pl $(PERLASM_SCHEME)
+-- 
+2.19.1
+

--- a/recipes-connectivity/openssl/openssl111/0001-skip-test_symbol_presence.patch
+++ b/recipes-connectivity/openssl/openssl111/0001-skip-test_symbol_presence.patch
@@ -1,0 +1,46 @@
+From a9401b2289656c5a36dd1b0ecebf0d23e291ce70 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Tue, 2 Oct 2018 23:58:24 +0800
+Subject: [PATCH] skip test_symbol_presence
+
+We cannot skip `01-test_symbol_presence.t' by configuring option `no-shared'
+as INSTALL told us the shared libraries will not be built.
+
+[INSTALL snip]
+ Notes on shared libraries
+ -------------------------
+
+ For most systems the OpenSSL Configure script knows what is needed to
+ build shared libraries for libcrypto and libssl. On these systems
+ the shared libraries will be created by default. This can be suppressed and
+ only static libraries created by using the "no-shared" option. On systems
+ where OpenSSL does not know how to build shared libraries the "no-shared"
+ option will be forced and only static libraries will be created.
+[INSTALL snip]
+
+Hence directly modification the case to skip it.
+
+Upstream-Status: Inappropriate [OE Specific]
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ test/recipes/01-test_symbol_presence.t | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/test/recipes/01-test_symbol_presence.t b/test/recipes/01-test_symbol_presence.t
+index 7f2a2d7..0b93745 100644
+--- a/test/recipes/01-test_symbol_presence.t
++++ b/test/recipes/01-test_symbol_presence.t
+@@ -14,8 +14,7 @@ use OpenSSL::Test::Utils;
+ 
+ setup("test_symbol_presence");
+ 
+-plan skip_all => "Only useful when building shared libraries"
+-    if disabled("shared");
++plan skip_all => "The case needs debug symbols then we just disable it";
+ 
+ my @libnames = ("crypto", "ssl");
+ my $testcount = scalar @libnames;
+-- 
+2.7.4
+

--- a/recipes-connectivity/openssl/openssl111/afalg.patch
+++ b/recipes-connectivity/openssl/openssl111/afalg.patch
@@ -1,0 +1,31 @@
+Don't refuse to build afalgeng if cross-compiling or the host kernel is too old.
+
+Upstream-Status: Submitted [hhttps://github.com/openssl/openssl/pull/7688]
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+diff --git a/Configure b/Configure
+index 3baa8ce..9ef52ed 100755
+--- a/Configure
++++ b/Configure
+@@ -1550,20 +1550,7 @@ unless ($disabled{"crypto-mdebug-backtrace"})
+ unless ($disabled{afalgeng}) {
+     $config{afalgeng}="";
+     if (grep { $_ eq 'afalgeng' } @{$target{enable}}) {
+-        my $minver = 4*10000 + 1*100 + 0;
+-        if ($config{CROSS_COMPILE} eq "") {
+-            my $verstr = `uname -r`;
+-            my ($ma, $mi1, $mi2) = split("\\.", $verstr);
+-            ($mi2) = $mi2 =~ /(\d+)/;
+-            my $ver = $ma*10000 + $mi1*100 + $mi2;
+-            if ($ver < $minver) {
+-                disable('too-old-kernel', 'afalgeng');
+-            } else {
+-                push @{$config{engdirs}}, "afalg";
+-            }
+-        } else {
+-            disable('cross-compiling', 'afalgeng');
+-        }
++        push @{$config{engdirs}}, "afalg";
+     } else {
+         disable('not-linux', 'afalgeng');
+     }

--- a/recipes-connectivity/openssl/openssl111/reproducible.patch
+++ b/recipes-connectivity/openssl/openssl111/reproducible.patch
@@ -1,0 +1,32 @@
+The value for perl_archname can vary depending on the host, e.g. 
+x86_64-linux-gnu-thread-multi or x86_64-linux-thread-multi which
+makes the ptest package non-reproducible. Its unused other than 
+these references so drop it.
+
+RP 2020/2/6
+
+Upstream-Status: Pending
+Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
+
+Index: openssl-1.1.1d/Configure
+===================================================================
+--- openssl-1.1.1d.orig/Configure
++++ openssl-1.1.1d/Configure
+@@ -286,7 +286,7 @@ if (defined env($local_config_envname))
+ # Save away perl command information
+ $config{perl_cmd} = $^X;
+ $config{perl_version} = $Config{version};
+-$config{perl_archname} = $Config{archname};
++#$config{perl_archname} = $Config{archname};
+ 
+ $config{prefix}="";
+ $config{openssldir}="";
+@@ -2517,7 +2517,7 @@ _____
+                           @{$config{perlargv}}), "\n";
+         print "\nPerl information:\n\n";
+         print '    ',$config{perl_cmd},"\n";
+-        print '    ',$config{perl_version},' for ',$config{perl_archname},"\n";
++        print '    ',$config{perl_version},"\n";
+     }
+     if ($dump || $options) {
+         my $longest = 0;

--- a/recipes-connectivity/openssl/openssl111/run-ptest
+++ b/recipes-connectivity/openssl/openssl111/run-ptest
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+# Optional arguments are 'list' to lists all tests, or the test name (base name
+# ie test_evp, not 03_test_evp.t).
+
+export TOP=.
+# OPENSSL_ENGINES is relative from the test binaries
+export OPENSSL_ENGINES=../engines
+
+perl ./test/run_tests.pl $* | perl -0pe 's#(.*) \.*.ok#PASS: \1#g; s#(.*) \.*.skipped: (.*)#SKIP: \1 (\2)#g; s#(.*) \.*.\nDubious#FAIL: \1#;'

--- a/recipes-connectivity/openssl/openssl111_1.1.1l.bb
+++ b/recipes-connectivity/openssl/openssl111_1.1.1l.bb
@@ -1,0 +1,220 @@
+SUMMARY = "Secure Socket Layer"
+DESCRIPTION = "Secure Socket Layer (SSL) binary and related cryptographic tools."
+HOMEPAGE = "http://www.openssl.org/"
+BUGTRACKER = "http://www.openssl.org/news/vulnerabilities.html"
+SECTION = "libs/network"
+
+# "openssl" here actually means both OpenSSL and SSLeay licenses apply
+# (see meta/files/common-licenses/OpenSSL to which "openssl" is SPDXLICENSEMAPped)
+LICENSE = "openssl"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d343e62fc9c833710bbbed25f27364c8"
+
+DEPENDS = "hostperl-runtime-native"
+
+SRC_URI = "http://www.openssl.org/source/openssl-${PV}.tar.gz \
+           file://run-ptest \
+           file://0001-skip-test_symbol_presence.patch \
+           file://0001-buildinfo-strip-sysroot-and-debug-prefix-map-from-co.patch \
+           file://afalg.patch \
+           file://reproducible.patch \
+           "
+
+SRC_URI:append:class-nativesdk = " \
+           file://environment.d-openssl.sh \
+           "
+
+SRC_URI[sha256sum] = "0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1"
+
+inherit lib_package multilib_header multilib_script ptest
+MULTILIB_SCRIPTS = "${PN}-bin:${bindir}/c_rehash"
+
+PACKAGECONFIG ?= ""
+PACKAGECONFIG:class-native = ""
+PACKAGECONFIG:class-nativesdk = ""
+
+PACKAGECONFIG[cryptodev-linux] = "enable-devcryptoeng,disable-devcryptoeng,cryptodev-linux,,cryptodev-module"
+
+S = "${WORKDIR}/openssl-${PV}"
+B = "${WORKDIR}/build"
+do_configure[cleandirs] = "${B}"
+
+DISABLE_STATIC = ""
+
+#| ./libcrypto.so: undefined reference to `getcontext'
+#| ./libcrypto.so: undefined reference to `setcontext'
+#| ./libcrypto.so: undefined reference to `makecontext'
+EXTRA_OECONF:append:libc-musl = " no-async"
+EXTRA_OECONF:append:libc-musl:powerpc64 = " no-asm"
+
+# adding devrandom prevents openssl from using getrandom() which is not available on older glibc versions
+# (native versions can be built with newer glibc, but then relocated onto a system with older glibc)
+EXTRA_OECONF:class-native = "--with-rand-seed=os,devrandom"
+EXTRA_OECONF:class-nativesdk = "--with-rand-seed=os,devrandom"
+
+# Relying on hardcoded built-in paths causes openssl-native to not be relocateable from sstate.
+CFLAGS:append:class-native = " -DOPENSSLDIR=/not/builtin -DENGINESDIR=/not/builtin"
+CFLAGS:append:class-nativesdk = " -DOPENSSLDIR=/not/builtin -DENGINESDIR=/not/builtin"
+
+do_configure () {
+	os=${HOST_OS}
+	case $os in
+	linux-gnueabi |\
+	linux-gnuspe |\
+	linux-musleabi |\
+	linux-muslspe |\
+	linux-musl )
+		os=linux
+		;;
+	*)
+		;;
+	esac
+	target="$os-${HOST_ARCH}"
+	case $target in
+	linux-arm*)
+		target=linux-armv4
+		;;
+	linux-aarch64*)
+		target=linux-aarch64
+		;;
+	linux-i?86 | linux-viac3)
+		target=linux-x86
+		;;
+	linux-gnux32-x86_64 | linux-muslx32-x86_64 )
+		target=linux-x32
+		;;
+	linux-gnu64-x86_64)
+		target=linux-x86_64
+		;;
+	linux-mips | linux-mipsel)
+		# specifying TARGET_CC_ARCH prevents openssl from (incorrectly) adding target architecture flags
+		target="linux-mips32 ${TARGET_CC_ARCH}"
+		;;
+	linux-gnun32-mips*)
+		target=linux-mips64
+		;;
+	linux-*-mips64 | linux-mips64 | linux-*-mips64el | linux-mips64el)
+		target=linux64-mips64
+		;;
+	linux-microblaze* | linux-nios2* | linux-sh3 | linux-sh4 | linux-arc*)
+		target=linux-generic32
+		;;
+	linux-powerpc)
+		target=linux-ppc
+		;;
+	linux-powerpc64)
+		target=linux-ppc64
+		;;
+	linux-powerpc64le)
+		target=linux-ppc64le
+		;;
+	linux-riscv32)
+		target=linux-generic32
+		;;
+	linux-riscv64)
+		target=linux-generic64
+		;;
+	linux-sparc | linux-supersparc)
+		target=linux-sparcv9
+		;;
+	esac
+
+	useprefix=${prefix}
+	if [ "x$useprefix" = "x" ]; then
+		useprefix=/
+	fi
+	# WARNING: do not set compiler/linker flags (-I/-D etc.) in EXTRA_OECONF, as they will fully replace the
+	# environment variables set by bitbake. Adjust the environment variables instead.
+	HASHBANGPERL="/usr/bin/env perl" PERL=perl PERL5LIB="${S}/external/perl/Text-Template-1.46/lib/" \
+	perl ${S}/Configure ${EXTRA_OECONF} ${PACKAGECONFIG_CONFARGS} --prefix=$useprefix --openssldir=${libdir}/ssl-1.1 --libdir=${libdir} $target
+	perl ${B}/configdata.pm --dump
+}
+
+do_install () {
+	# Normal install target also does install_docs, which we don't
+	# want here.
+	oe_runmake DESTDIR="${D}" install_sw install_ssldirs
+	install -d ${D}${includedir}/openssl-1.1
+	mv ${D}${includedir}/openssl ${D}${includedir}/openssl-1.1
+	for pcf in openssl libssl libcrypto; do
+	    mv ${D}${libdir}/pkgconfig/$pcf.pc ${D}${libdir}/pkgconfig/$pcf-1.1.pc
+	    sed -i -e's,/include$,/include/openssl-1.1,' -e's,/${baselib}$,/${baselib}/openssl-1.1,' ${D}${libdir}/pkgconfig/$pcf-1.1.pc
+	done
+	oe_multilib_header openssl-1.1/openssl/opensslconf.h
+	# Move .so symlinks and static libraries to a subdirectory
+	install -d ${D}${libdir}/openssl-1.1
+	for libname in crypto ssl; do
+	    rm -f ${D}${libdir}/lib$libname.so
+	    ln -s ../lib$libname.so.1.1 ${D}${libdir}/openssl-1.1/lib$libname.so
+	    mv ${D}${libdir}/lib$libname.a ${D}${libdir}/openssl-1.1/
+	done
+}
+
+do_install:append:class-native () {
+	create_wrapper ${D}${bindir}/openssl-1.1 \
+	    OPENSSL_CONF=${libdir}/ssl-1.1/openssl.cnf \
+	    SSL_CERT_DIR=${libdir}/ssl-1.1/certs \
+	    SSL_CERT_FILE=${libdir}/ssl-1.1/cert.pem \
+	    OPENSSL_ENGINES=${libdir}/engines-1.1
+}
+
+do_install:append:class-nativesdk () {
+	mkdir -p ${D}${SDKPATHNATIVE}/environment-setup.d
+	install -m 644 ${WORKDIR}/environment.d-openssl.sh ${D}${SDKPATHNATIVE}/environment-setup.d/openssl.sh
+	sed 's|/usr/lib/ssl/|/usr/lib/ssl-1.1/|g' -i ${D}${SDKPATHNATIVE}/environment-setup.d/openssl.sh
+}
+
+PTEST_BUILD_HOST_FILES += "configdata.pm"
+PTEST_BUILD_HOST_PATTERN = "perl_version ="
+do_install_ptest () {
+	# Prune the build tree
+	rm -f ${B}/fuzz/*.* ${B}/test/*.*
+
+	cp ${S}/Configure ${B}/configdata.pm ${D}${PTEST_PATH}
+	cp -r ${S}/external ${B}/test ${S}/test ${B}/fuzz ${S}/util ${B}/util ${D}${PTEST_PATH}
+
+	# For test_shlibload
+	ln -s ${libdir}/libcrypto.so.1.1 ${D}${PTEST_PATH}/
+	ln -s ${libdir}/libssl.so.1.1 ${D}${PTEST_PATH}/
+
+	install -d ${D}${PTEST_PATH}/apps
+	ln -s ${bindir}/openssl ${D}${PTEST_PATH}/apps
+	install -m644 ${S}/apps/*.pem ${S}/apps/*.srl ${S}/apps/openssl.cnf ${D}${PTEST_PATH}/apps
+	install -m755 ${B}/apps/CA.pl ${D}${PTEST_PATH}/apps
+
+	install -d ${D}${PTEST_PATH}/engines
+	install -m755 ${B}/engines/ossltest.so ${D}${PTEST_PATH}/engines
+}
+
+# Add the openssl.cnf file to the openssl-conf package. Make the libcrypto
+# package RRECOMMENDS on this package. This will enable the configuration
+# file to be installed for both the openssl-bin package and the libcrypto
+# package since the openssl-bin package depends on the libcrypto package.
+
+PACKAGES =+ "libcrypto111 libssl111 ${BPN}-conf ${PN}-engines ${PN}-misc"
+
+FILES:libcrypto111 = "${libdir}/libcrypto${SOLIBS}"
+FILES:libssl111 = "${libdir}/libssl${SOLIBS}"
+FILES:${BPN}-conf = "${libdir}/ssl-1.1/openssl.cnf*"
+FILES:${PN}-engines = "${libdir}/engines-1.1"
+FILES:${PN}-misc = "${libdir}/ssl-1.1/misc"
+FILES:${PN} =+ "${libdir}/ssl-1.1/*"
+FILES:${PN}-dev += "${libdir}/openssl-1.1/lib*${SOLIBSDEV}"
+FILES:${PN}-staticdev += "${libdir}/openssl-1.1/lib*.a"
+FILES:${PN}:append:class-nativesdk = " ${SDKPATHNATIVE}/environment-setup.d/${BPN}.sh"
+
+CONFFILES:${BPN}-conf = "${sysconfdir}/ssl/openssl.cnf"
+
+RRECOMMENDS:libcrypto111 += "${BPN}-conf"
+RDEPENDS:${PN}-ptest += "${PN}-bin perl perl-modules bash"
+
+RDEPENDS:${PN}-bin += "${BPN}-conf"
+
+BBCLASSEXTEND = "native nativesdk"
+
+CVE_PRODUCT = "openssl:openssl"
+
+CVE_VERSION_SUFFIX = "alphabetical"
+
+# Only affects OpenSSL >= 1.1.1 in combination with Apache < 2.4.37
+# Apache in meta-webserver is already recent enough
+CVE_CHECK_WHITELIST += "CVE-2019-0190"

--- a/recipes-devtools/deepstream/deepstream-6.0_6.0.0-1.bb
+++ b/recipes-devtools/deepstream/deepstream-6.0_6.0.0-1.bb
@@ -1,0 +1,135 @@
+DESCRIPTION = "NVIDIA Deepstream SDK"
+HOMEPAGE = "https://developer.nvidia.com/deepstream-sdk"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = " \
+    file://usr/share/doc/deepstream-6.0/copyright;md5=7a5ffdb833cdefe5ac34aaa81de173a3 \
+    file://opt/nvidia/deepstream/deepstream-6.0/LICENSE.txt;md5=5dcf86799aa20202668e226e93f9cfd9 \
+    file://opt/nvidia/deepstream/deepstream-6.0/doc/nvidia-tegra/LICENSE.iothub_client;md5=4f8c6347a759d246b5f96281726b8611 \
+    file://opt/nvidia/deepstream/deepstream-6.0/doc/nvidia-tegra/LICENSE.nvds_amqp_protocol_adaptor;md5=8b4b651fa4090272b2e08e208140a658 \
+"
+
+inherit l4t_deb_pkgfeed
+
+SRC_COMMON_DEBS = "${BPN}_${PV}_arm64.deb;subdir=${BPN}"
+SRC_URI[sha256sum] = "320927fe83b40bea2da5408f6777985065038c7f1506b2f5d5eaa0bcfc2a1564"
+
+COMPATIBLE_MACHINE = "(tegra)"
+PACKAGE_ARCH = "${TEGRA_PKGARCH}"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[amqp] = ",,rabbitmq-c"
+PACKAGECONFIG[kafka] = ",,librdkafka"
+# NB: requires hiredis 1.0.0+
+PACKAGECONFIG[redis] = ",,hiredis"
+# NB: need recipes for these dependencies
+PACKAGECONFIG[azure] = ""
+PACKAGECONFIG[triton] = ""
+PACKAGECONFIG[rivermax] = ""
+
+DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-rtsp-server \
+    tensorrt-core tensorrt-plugins libnvvpi1 libvisionworks libnpp json-glib \
+    openssl111 tegra-libraries-multimedia \
+"
+
+S = "${WORKDIR}/${BPN}"
+B = "${WORKDIR}/build"
+
+DEEPSTREAM_PATH = "/opt/nvidia/deepstream/deepstream-6.0"
+SYSROOT_DIRS += "${DEEPSTREAM_PATH}/lib/"
+
+do_configure() {
+    for feature in azure amqp kafka redis triton rivermax; do
+        if ! echo "${PACKAGECONFIG}" | grep -q "$feature"; then
+            rm -f ${S}${DEEPSTREAM_PATH}/lib/libnvds_${feature}*
+            if [ "$feature" = "azure" ]; then
+                rm -f ${S}${DEEPSTREAM_PATH}/lib/libiothub_client.so
+            fi
+            if [ "$feature" = "triton" ]; then
+                rm -f ${S}${DEEPSTREAM_PATH}/lib/gst-plugins/libnvdsgst_inferserver.so
+                rm -f ${S}${DEEPSTREAM_PATH}/lib/libnvds_infer_server.so
+            fi
+            if [ "$feature" = "rivermax" ]; then
+                rm -f ${S}${DEEPSTREAM_PATH}/lib/gst-plugins/libnvdsgst_udp.so
+            fi
+        fi
+    done
+}
+
+do_install() {
+    install -d ${D}${bindir}/
+    install -m 0755 ${S}${DEEPSTREAM_PATH}/bin/* ${D}${bindir}/
+
+    install -d ${D}${DEEPSTREAM_PATH}/lib/
+    for f in ${S}${DEEPSTREAM_PATH}/lib/*; do
+        [ ! -d "$f" ] || continue
+        install -m 0644 "$f" ${D}${DEEPSTREAM_PATH}/lib/
+    done
+    ln -sf libnvds_msgconv.so.1.0.0 ${D}${DEEPSTREAM_PATH}/lib/libnvds_msgconv.so
+    ln -sf libnvds_msgconv_audio.so.1.0.0 ${D}${DEEPSTREAM_PATH}/lib/libnvds_msgconv_audio.so
+
+    cp -R --preserve=mode,timestamps ${S}${DEEPSTREAM_PATH}/lib/cvcore_libs/ ${D}${DEEPSTREAM_PATH}/lib/
+
+    install -d ${D}/${sysconfdir}/ld.so.conf.d/
+    echo "${DEEPSTREAM_PATH}/lib" > ${D}/${sysconfdir}/ld.so.conf.d/deepstream.conf
+    echo "${libdir}/gstreamer-1.0/deepstream" >> ${D}/${sysconfdir}/ld.so.conf.d/deepstream.conf
+
+    install -d ${D}${libdir}/gstreamer-1.0/deepstream
+    install -m 0644 ${S}${DEEPSTREAM_PATH}/lib/gst-plugins/* ${D}${libdir}/gstreamer-1.0/deepstream/
+
+    cp -R --preserve=mode,timestamps ${S}${DEEPSTREAM_PATH}/samples ${D}${DEEPSTREAM_PATH}/
+
+    install -d ${D}${includedir}/deepstream
+    cp -R --preserve=mode,timestamps ${S}${DEEPSTREAM_PATH}/sources/includes/* ${D}${includedir}/
+
+    cp -R --preserve=mode,timestamps ${S}${DEEPSTREAM_PATH}/sources/ ${D}${DEEPSTREAM_PATH}/
+}
+
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+INSANE_SKIP = "dev-so ldflags"
+
+def pkgconf_packages(d):
+    pkgconf = bb.utils.filter('PACKAGECONFIG', 'azure amqp kafka redis triton rivermax', d).split()
+    pn = d.getVar('PN')
+    return ' '.join(['{}-{}'.format(pn, p) for p in pkgconf])
+
+PKGCONF_PACKAGES = "${@pkgconf_packages(d)}"
+
+PACKAGES =+ "${PN}-samples-data ${PN}-samples ${PN}-sources ${PKGCONF_PACKAGES}"
+
+FILES:${PN} = "\
+    ${sysconfdir}/ld.so.conf.d/  \
+    ${libdir}/gstreamer-1.0/deepstream \
+    ${DEEPSTREAM_PATH}/lib \
+"
+
+FILES:${PN}-dev = "${includedir}"
+
+FILES:${PN}-samples = "${bindir}/*"
+FILES:${PN}-samples-data = "\
+    ${DEEPSTREAM_PATH}/samples \
+    ${DEEPSTREAM_PATH}/sources/apps/sample_apps/*/*.txt \
+    ${DEEPSTREAM_PATH}/sources/apps/sample_apps/*/README \
+    ${DEEPSTREAM_PATH}/sources/apps/sample_apps/*/configs/ \
+    ${DEEPSTREAM_PATH}/sources/apps/sample_apps/*/inferserver/ \
+    ${DEEPSTREAM_PATH}/sources/apps/sample_apps/*/csv_files/ \
+"
+
+FILES:${PN}-sources = "${DEEPSTREAM_PATH}/sources"
+
+FILES:${PN}-azure = "${DEEPSTREAM_PATH}/lib/libiothub_client.so ${DEEPSTREAM_PATH}/lib/libnvds_azure*"
+FILES:${PN}-triton = "\
+    ${libdir}/gstreamer-1.0/deepstream/libnvdsgst_inferserver.so \
+    ${DEEPSTREAM_PATH}/lib/libnvds_infer_server.so \
+"
+FILES:${PN}-amqp = "${DEEPSTREAM_PATH}/lib/libnvds_amqp*"
+FILES:${PN}-kafka = "${DEEPSTREAM_PATH}/lib/libnvds_kafka*"
+FILES:${PN}-redis = "${DEEPSTREAM_PATH}/lib/libnvds_redis*"
+FILES:${PN}-rivermax = "${libdir}/gstreamer-1.0/deepstream/libnvdsgst_udp.so"
+
+RDEPENDS:${PN} = "libvisionworks-devso-symlink"
+RDEPENDS:${PN}-samples = "${PN}-samples-data"
+RDEPENDS:${PN}-samples-data = "bash"
+RDEPENDS:${PN}-sources = "bash ${PN}-samples-data ${PN}"
+RRECOMMENDS:${PN} = "liberation-fonts"


### PR DESCRIPTION
* Imports a recipe for openssl 1.1.1 to allow it to co-reside with openssl 3, to satisfy the runtime dependencies for the DS-6.0 prebuilt libraries
* Recipe for DS-6.0 excludes features with other dependencies that we do not have recipes for via PACKAGECONFIG settings.
