### PR TITLE
python3-jetson-stats: new recipe

### DIFF
--- a/recipes-devtools/python/python3-jetson-stats/0001-jtop-fix-no-attribute-issue.patch
+++ b/recipes-devtools/python/python3-jetson-stats/0001-jtop-fix-no-attribute-issue.patch
@@ -1,0 +1,28 @@
+From 50988ee48f5375f6aae940664fd9b64ebacacb16 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ilies.chergui@gmail.com>
+Date: Wed, 16 Feb 2022 10:54:16 +0000
+Subject: [PATCH] jtop: fix no attribute issue
+
+AttributeError: 'array.array' object has no attribute 'tostring'
+
+Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+---
+ jtop/core/common.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/jtop/core/common.py b/jtop/core/common.py
+index 5732f29..64b0ae3 100644
+--- a/jtop/core/common.py
++++ b/jtop/core/common.py
+@@ -176,7 +176,7 @@ def get_local_interfaces():
+     max_bytes_out, names_address_out = struct.unpack('iL', mutated_byte_buffer)
+     # Convert names to a bytes array - keep in mind we've mutated the names array, so now our bytes out should represent
+     # the bytes results of the get iface list ioctl command.
+-    namestr = names.tostring()
++    namestr = names.tobytes()
+     # Each entry is 40 bytes long.  The first 16 bytes are the name string.
+     # the 20-24th bytes are IP address octet strings in byte form - one for each byte.
+     # Don't know what 17-19 are, or bytes 25:40.
+-- 
+2.17.1
+

--- a/recipes-devtools/python/python3-jetson-stats_3.1.2.bb
+++ b/recipes-devtools/python/python3-jetson-stats_3.1.2.bb
@@ -1,0 +1,51 @@
+SUMMARY = "Interactive system-monitor process viewer for NVIDIA Jetson Nano, AGX Xavier, TX2, TX1"
+HOMEPAGE = "https://pypi.org/project/jetson-stats/"
+SECTION = "devel/python"
+LICENSE = "AGPL-3.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=8763b57f0092c337eb12c354870a324a"
+
+SRC_URI[sha256sum] = "afab3db7da554ad14df7b7eee4d0bc3338c827625c690dda0ac4ddd6051d315a"
+SRC_URI += "file://0001-jtop-fix-no-attribute-issue.patch"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+inherit pypi setuptools3 systemd useradd
+
+do_install:append() {
+    # Need to move the systemd service into the right place manually and adjust
+    # the ExecStart path.
+    mkdir -p ${D}${systemd_system_unitdir}
+    mv ${D}${datadir}/jetson_stats/jetson_stats.service \
+        ${D}${systemd_system_unitdir}/jetson_stats.service
+    sed -i 's/ExecStart=\/usr\/local\/bin\/jtop/ExecStart=\/usr\/bin\/jtop/g' \
+        ${D}${systemd_system_unitdir}/jetson_stats.service
+
+    # Remove stuff that requires dpkg and is aimed at jetpack anyway
+    rm ${D}${bindir}/jetson_config
+    rm ${D}${bindir}/jetson_swap
+    rm ${D}${bindir}/jetson_release
+    rm ${D}${datadir}/jetson_stats/jetson_env.sh
+}
+
+SYSTEMD_SERVICE:${PN} = "jetson_stats.service"
+
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM:${PN} = "-r -d ${libexecdir} -M -s ${base_sbindir}/nologin -g jetson_stats jetson_stats"
+GROUPADD_PARAM:${PN} = "-f -r jetson_stats"
+
+RDEPENDS:${PN} += " \
+    bash \
+    python3-curses \
+    python3-email \
+    python3-fcntl \
+    python3-json \
+    python3-multiprocessing \
+    python3-setuptools \
+    tegra-nvpmodel \
+    tegra-tools-jetson-clocks \
+    tegra-tools-tegrastats \
+"
+
+RRECOMMENDS:${PN} += "kernel-module-nvgpu"
+
+FILES:${PN} += "${datadir}/jetson_stats"


### PR DESCRIPTION
This adds a recipe for the jetson-stats tool. It makes it somewhat easier to monitor resource usage than with tegrastats.