### PR TITLE
libevhtp: new recipe

### DIFF
--- a/recipes-devtools/libevhtp/libevhtp/0001-fix-cmake-build.patch
+++ b/recipes-devtools/libevhtp/libevhtp/0001-fix-cmake-build.patch
@@ -1,0 +1,43 @@
+From 491ecafe3b3b8651fa51a3234170cabb394e15d8 Mon Sep 17 00:00:00 2001
+From: Roger Knecht <roger@norberthealth.com>
+Date: Wed, 22 Jun 2022 11:17:05 +0200
+Subject: [PATCH] fix cmake build
+
+---
+ CMakeLists.txt        | 4 ++--
+ cmake/Config.cmake.in | 3 +++
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 481ddd0..dcf5685 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -54,10 +54,10 @@ set(LIBEVHTP_SOURCE_FILES
+     parser.c
+     log.c)
+ 
+-find_package(LibEvent REQUIRED)
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(LibEvent REQUIRED libevent)
+ list(APPEND LIBEVHTP_EXTERNAL_LIBS ${LIBEVENT_LIBRARIES})
+ list(APPEND LIBEVHTP_EXTERNAL_INCLUDES ${LIBEVENT_INCLUDE_DIRS})
+-list(APPEND package_deps LibEvent)
+ 
+ set(evhtp_dir_headers
+   "include/evhtp/evhtp.h"
+diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
+index b834857..20a2e07 100644
+--- a/cmake/Config.cmake.in
++++ b/cmake/Config.cmake.in
+@@ -1,5 +1,8 @@
+ @PACKAGE_INIT@
+ 
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(LibEvent REQUIRED libevent)
++
+ set(package_deps @package_deps@)
+ foreach(dep IN LISTS package_deps)
+     find_package(${dep} REQUIRED)
+-- 
+2.17.1
+

--- a/recipes-devtools/libevhtp/libevhtp_1.2.18.bb
+++ b/recipes-devtools/libevhtp/libevhtp_1.2.18.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "Create extremely-fast and secure embedded HTTP servers with ease."
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=68e2a80f5f9020a66f4512962817cd66"
+
+SRC_URI = " \
+    git://github.com/Yellow-Camper/libevhtp.git;protocol=https;branch=master \
+    file://0001-fix-cmake-build.patch \
+"
+
+SRCREV = "e200bfa85bf253e9cfe1c1a9e705fccb176b9171"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "libevent"
+
+PACKAGECONFIG ??= "pthreads"
+PACKAGECONFIG[openssl] = "-DEVHTP_DISABLE_SSL=OFF,-DEVHTP_DISABLE_SSL=ON,openssl"
+PACKAGECONFIG[onig] = "-DEVHTP_DISABLE_REGEX=OFF,-DEVHTP_DISABLE_REGEX=ON,onig"
+PACKAGECONFIG[pthreads] = "-DEVHTP_DISABLE_EVTHR=OFF,-DEVHTP_DISABLE_EVTHR=ON"
+
+inherit pkgconfig cmake


### PR DESCRIPTION
libevhtp is an embedded HTTP server library.
This recipe is a dependency for NVIDIA Triton.