### PR TITLE
python3-jepture: new package

### DIFF
--- a/recipes-devtools/python/python3-jepture/0001-setup.py-don-t-hardcode-paths.patch
+++ b/recipes-devtools/python/python3-jepture/0001-setup.py-don-t-hardcode-paths.patch
@@ -1,0 +1,60 @@
+From 22616a6f45b33962f231232993e3b3cb97ecda52 Mon Sep 17 00:00:00 2001
+From: Bartosz Golaszewski <brgl@bgdev.pl>
+Date: Wed, 13 Jul 2022 15:45:22 +0200
+Subject: [PATCH 1/2] setup.py: don't hardcode paths
+
+The setup script was written for jetpack. This modifies it to work with
+local sources.
+
+Signed-off-by: Bartosz Golaszewski <brgl@bgdev.pl>
+---
+Upstream-Status: Inappropriate [yocto-specific]
+
+ setup.py | 16 ++++++----------
+ 1 file changed, 6 insertions(+), 10 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 63dac42..bf43e48 100644
+--- a/setup.py
++++ b/setup.py
+@@ -18,23 +18,20 @@ __version__ = "0.0.1"
+ #   Sort input source files if you glob sources to ensure bit-for-bit
+ #   reproducible builds (https://github.com/pybind/python_example/pull/53)
+ 
+-include_dirs = [ "/usr/src/jetson_multimedia_api/include"
+-    , "/usr/src/jetson_multimedia_api/include/libjpeg-8b" ]
++include_dirs = [ "jetson_multimedia_api/usr/src/jetson_multimedia_api/include"
++    , "jetson_multimedia_api/usr/src/jetson_multimedia_api/include/libjpeg-8b" ]
+         
+ 
+-library_dirs = [ "/usr/local/cuda/lib64"
+-        , "/usr/lib/aarch64-linux-gnu/tegra"]
+-
+ libraries = [ "nvargus_socketclient"
+     , "nvjpeg"
+     , "EGL"
+     , "nvbuf_utils" ]
+ 
+ 
+-nvidia_source = [ "/usr/src/jetson_multimedia_api/samples/common/classes/NvJpegEncoder.cpp",
+-        "/usr/src/jetson_multimedia_api/samples/common/classes/NvElement.cpp",
+-        "/usr/src/jetson_multimedia_api/samples/common/classes/NvElementProfiler.cpp",
+-        "/usr/src/jetson_multimedia_api/samples/common/classes/NvLogging.cpp",
++nvidia_source = [ "jetson_multimedia_api/usr/src/jetson_multimedia_api/samples/common/classes/NvJpegEncoder.cpp",
++        "jetson_multimedia_api/usr/src/jetson_multimedia_api/samples/common/classes/NvElement.cpp",
++        "jetson_multimedia_api/usr/src/jetson_multimedia_api/samples/common/classes/NvElementProfiler.cpp",
++        "jetson_multimedia_api/usr/src/jetson_multimedia_api/samples/common/classes/NvLogging.cpp",
+         ]
+ 
+ sources = list(glob("src/*.cpp"))
+@@ -48,7 +45,6 @@ ext_modules = [
+         define_macros = [('VERSION_INFO', __version__)],
+         include_dirs = include_dirs,
+         libraries = libraries,
+-        library_dirs = library_dirs
+         ),
+ ]
+ 
+-- 
+2.34.1
+

--- a/recipes-devtools/python/python3-jepture/0002-v4l2-remove-duplicate-symbols-from-nvidia-extensions.patch
+++ b/recipes-devtools/python/python3-jepture/0002-v4l2-remove-duplicate-symbols-from-nvidia-extensions.patch
@@ -1,0 +1,102 @@
+From bf920dd14aefad9e159f92717745465e0b03d2f6 Mon Sep 17 00:00:00 2001
+From: Bartosz Golaszewski <brgl@bgdev.pl>
+Date: Wed, 13 Jul 2022 16:31:42 +0200
+Subject: [PATCH 2/2] v4l2: remove duplicate symbols from nvidia extensions
+
+The jetpack headers redefine certain v4l2 symbols. Remove them when
+building jepture.
+
+Signed-off-by: Bartosz Golaszewski <brgl@bgdev.pl>
+---
+Upstream-Status: Inappropriate [yocto-specific]
+
+ .../include/v4l2_nv_extensions.h              | 59 -------------------
+ 1 file changed, 59 deletions(-)
+
+diff --git a/jetson_multimedia_api/usr/src/jetson_multimedia_api/include/v4l2_nv_extensions.h b/jetson_multimedia_api/usr/src/jetson_multimedia_api/include/v4l2_nv_extensions.h
+index 5617508..b49bd0d 100644
+--- a/jetson_multimedia_api/usr/src/jetson_multimedia_api/include/v4l2_nv_extensions.h
++++ b/jetson_multimedia_api/usr/src/jetson_multimedia_api/include/v4l2_nv_extensions.h
+@@ -176,26 +176,6 @@ enum v4l2_mpeg_video_h265_profile {
+ #define V4L2_H264_SPS_FLAG_FRAME_MBS_ONLY           0x10
+ #define V4L2_H264_SPS_FLAG_MB_ADAPTIVE_FRAME_FIELD      0x20
+ #define V4L2_H264_SPS_FLAG_DIRECT_8X8_INFERENCE         0x40
+-struct v4l2_ctrl_h264_sps {
+-    __u8 profile_idc;
+-    __u8 constraint_set_flags;
+-    __u8 level_idc;
+-    __u8 seq_parameter_set_id;
+-    __u8 chroma_format_idc;
+-    __u8 bit_depth_luma_minus8;
+-    __u8 bit_depth_chroma_minus8;
+-    __u8 log2_max_frame_num_minus4;
+-    __u8 pic_order_cnt_type;
+-    __u8 log2_max_pic_order_cnt_lsb_minus4;
+-    __s32 offset_for_non_ref_pic;
+-    __s32 offset_for_top_to_bottom_field;
+-    __u8 num_ref_frames_in_pic_order_cnt_cycle;
+-    __s32 offset_for_ref_frame[255];
+-    __u8 max_num_ref_frames;
+-    __u16 pic_width_in_mbs_minus1;
+-    __u16 pic_height_in_map_units_minus1;
+-    __u8 flags;
+-};
+ 
+ #define V4L2_H264_PPS_FLAG_ENTROPY_CODING_MODE              0x0001
+ #define V4L2_H264_PPS_FLAG_BOTTOM_FIELD_PIC_ORDER_IN_FRAME_PRESENT  0x0002
+@@ -205,31 +185,6 @@ struct v4l2_ctrl_h264_sps {
+ #define V4L2_H264_PPS_FLAG_REDUNDANT_PIC_CNT_PRESENT            0x0020
+ #define V4L2_H264_PPS_FLAG_TRANSFORM_8X8_MODE               0x0040
+ #define V4L2_H264_PPS_FLAG_PIC_SCALING_MATRIX_PRESENT           0x0080
+-struct v4l2_ctrl_h264_pps {
+-    __u8 pic_parameter_set_id;
+-    __u8 seq_parameter_set_id;
+-    __u8 num_slice_groups_minus1;
+-    __u8 num_ref_idx_l0_default_active_minus1;
+-    __u8 num_ref_idx_l1_default_active_minus1;
+-    __u8 weighted_bipred_idc;
+-    __s8 pic_init_qp_minus26;
+-    __s8 pic_init_qs_minus26;
+-    __s8 chroma_qp_index_offset;
+-    __s8 second_chroma_qp_index_offset;
+-    __u8 flags;
+-};
+-
+-struct v4l2_ctrl_h264_scaling_matrix {
+-    __u8 scaling_list_4x4[6][16];
+-    __u8 scaling_list_8x8[6][64];
+-};
+-
+-struct v4l2_h264_weight_factors {
+-    __s8 luma_weight[32];
+-    __s8 luma_offset[32];
+-    __s8 chroma_weight[32][2];
+-    __s8 chroma_offset[32][2];
+-};
+ 
+ struct v4l2_h264_pred_weight_table {
+     __u8 luma_log2_weight_denom;
+@@ -283,20 +238,6 @@ struct v4l2_ctrl_h264_slice_param {
+     __u8 flags;
+ };
+ 
+-/** Defines whether the v4l2_h264_dpb_entry structure is used.
+-If not set, this entry is unused for reference. */
+-#define V4L2_H264_DPB_ENTRY_FLAG_ACTIVE     0x01
+-#define V4L2_H264_DPB_ENTRY_FLAG_LONG_TERM  0x02
+-struct v4l2_h264_dpb_entry {
+-    __u32 buf_index; /**< v4l2_buffer index. */
+-    __u16 frame_num;
+-    __u16 pic_num;
+-    /** @note `v4l2_buffer.field` specifies this field. */
+-    __s32 top_field_order_cnt;
+-    __s32 bottom_field_order_cnt;
+-    __u8 flags; /* V4L2_H264_DPB_ENTRY_FLAG_* */
+-};
+-
+ struct v4l2_ctrl_h264_decode_param {
+     __u32 num_slices;
+     __u8 idr_pic_flag;
+-- 
+2.34.1
+

--- a/recipes-devtools/python/python3-jepture/0003-Revert-argus_stream-update-certain-symbols-to-work-w.patch
+++ b/recipes-devtools/python/python3-jepture/0003-Revert-argus_stream-update-certain-symbols-to-work-w.patch
@@ -1,0 +1,36 @@
+From aac3537859395e41b00a0fc5612c5159918df533 Mon Sep 17 00:00:00 2001
+From: Bartosz Golaszewski <brgl@bgdev.pl>
+Date: Fri, 29 Jul 2022 14:57:42 +0200
+Subject: [PATCH] Revert "argus_stream: update certain symbols to work with
+ jetpack 5.0.1"
+
+This reverts commit b5776b5c8207341d3e9708b8a9dd6bd9f824f8b1.
+
+Upstream master works with jetpack 5.0.1 but we cannot just checkout the
+commit before this change as at the time the repo didn't have any
+license.
+
+Signed-off-by: Bartosz Golaszewski <brgl@bgdev.pl>
+---
+Upstream-Status: Inappropriate [yocto-specific]
+
+ src/argus_stream.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/argus_stream.cpp b/src/argus_stream.cpp
+index 6866afd..0c6bb6a 100644
+--- a/src/argus_stream.cpp
++++ b/src/argus_stream.cpp
+@@ -372,8 +372,8 @@ std::vector<ArgusStreamOutput> ArgusStream::next(bool skip){
+ 
+             if(!this->cameras[i]->dma_buffer){
+                 this->cameras[i]->dma_buffer = native_buffer->createNvBuffer(this->cameras[i]->i_stream->getResolution(),
+-                        NVBUF_COLOR_FORMAT_YUV420,
+-                        NVBUF_LAYOUT_BLOCK_LINEAR);
++                        NvBufferColorFormat_YUV420,
++                        NvBufferLayout_BlockLinear);
+                 if(!this->cameras[i]->dma_buffer){
+                     throw std::runtime_error("failed to create dma buffer");
+                 }
+-- 
+2.34.1

--- a/recipes-devtools/python/python3-jepture_git.bb
+++ b/recipes-devtools/python/python3-jepture_git.bb
@@ -1,0 +1,34 @@
+SUMMARY = "A simple python library to quickly capture images on the Jetson."
+LICENSE = "Proprietary & BSD-3-Clause & MIT"
+LIC_FILES_CHKSUM = " \
+    file://LICENSE.md;md5=4f0a72805ccc91536540a1cf89a935ec \
+    file://jetson_multimedia_api/usr/src/jetson_multimedia_api/argus/LICENSE.TXT;md5=271791ce6ff6f928d44a848145021687 \
+"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+L4T_DEB_SOCNAME = "t186"
+L4T_BSP_DEB_VERSION = "${L4T_BSP_DEB_DEFAULT_VERSION_T186}"
+PKG_VER = "${L4T_VERSION}${@l4t_bsp_debian_version_suffix(d)}"
+SRC_SOC_DEBS = "nvidia-l4t-jetson-multimedia-api_${PKG_VER}_arm64.deb;subdir=git/jetson_multimedia_api"
+
+inherit setuptools3 l4t_deb_pkgfeed
+
+SRC_URI =+ " \
+    git://github.com/DelSkayn/jepture.git;protocol=https;branch=main \
+    file://0001-setup.py-don-t-hardcode-paths.patch \
+    file://0002-v4l2-remove-duplicate-symbols-from-nvidia-extensions.patch \
+    file://0003-Revert-argus_stream-update-certain-symbols-to-work-w.patch \
+"
+
+SRC_URI[sha256sum] = "40225cf5279fc8ded8a29966e7923d1bdf5a7eb9ff5bee2c016fec2db40a786a"
+SRCREV = "be40d9219e0f2eb69141f632181ae8c0ba969413"
+PV = "git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = " \
+    python3-pybind11-native \
+    tegra-libraries-multimedia \
+    tegra-libraries-camera \
+"


### PR DESCRIPTION
I've had a lot of trouble getting camera capture to work correctly with nvargus. The problem is that the daemon continuously captures frames and if you consume them using the gstreamer module, you can't set the daemon's framerate and you need to consume them at the same rate as the server captures them. I found this python module called jepture that captures frames directly without going through the gstreamer plugin. This PR adds a recipe for it.