### PR TITLE
triton-client: add triton-client http bindings for python

### DIFF
--- a/recipes-devtools/dlpack/dlpack_0.7.bb
+++ b/recipes-devtools/dlpack/dlpack_0.7.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Common in-memory tensor structure"
+HOMEPAGE = "https://github.com/dmlc/dlpack"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f62d4e85ba68a1574b74d97ab8dea9ab"
+
+SRC_URI = "git://github.com/dmlc/dlpack.git;protocol=https;branch=main"
+
+SRCREV = "e2bdd3bee8cb6501558042633fa59144cc8b7f5f"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+PACKAGECONFIG = ""
+PACKAGECONFIG[docs] = "-DBUILD_DOCS=ON,-DBUILD_DOCS=OFF"
+PACKAGECONFIG[mock] = "-DBUILD_MOCK=ON,-DBUILD_MOCK=OFF"
+
+ALLOW_EMPTY:${PN} = "1"

--- a/recipes-devtools/python/python3-geventhttpclient_2.0.8.bb
+++ b/recipes-devtools/python/python3-geventhttpclient_2.0.8.bb
@@ -1,0 +1,15 @@
+SUMMARY = "A high performance, concurrent http client library for python with gevent"
+HOMEPAGE = "https://github.com/geventhttpclient/geventhttpclient"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=c90481ab10d7e28d51bd403cbd83e963 \
+                    file://llhttp/LICENSE-MIT;md5=f5e274d60596dd59be0a1d1b19af7978"
+
+SRC_URI = "gitsm://github.com/geventhttpclient/geventhttpclient.git;protocol=https;branch=master"
+SRCREV = "bbafdf35d9ca1061da27e5c6fd4733fe3b0ef0f7"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+RDEPENDS:${PN} = "python3"

--- a/recipes-devtools/python/python3-rapidjson_1.9.bb
+++ b/recipes-devtools/python/python3-rapidjson_1.9.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Python wrapper around rapidjson"
+HOMEPAGE = "https://github.com/python-rapidjson/python-rapidjson"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=4daf3929156304df67003c33274a98bd \
+                    file://rapidjson/license.txt;md5=ba04aa8f65de1396a7e59d1d746c2125 \
+                    file://rapidjson/bin/jsonschema/LICENSE;md5=9d4de43111d33570c8fe49b4cb0e01af \
+                    file://rapidjson/contrib/natvis/LICENSE;md5=ec259ab094c66e4776e1da8b023540e0 \
+                    file://rapidjson/thirdparty/gtest/LICENSE;md5=cbbd27594afd089daa160d3a16dd515a \
+                    file://rapidjson/thirdparty/gtest/googlemock/LICENSE;md5=cbbd27594afd089daa160d3a16dd515a \
+                    file://rapidjson/thirdparty/gtest/googlemock/scripts/generator/LICENSE;md5=2c0b90db7465231447cf2dd2e8163333 \
+                    file://rapidjson/thirdparty/gtest/googletest/LICENSE;md5=cbbd27594afd089daa160d3a16dd515a"
+
+SRC_URI = "gitsm://github.com/python-rapidjson/python-rapidjson.git;protocol=https;branch=master"
+
+SRCREV = "8f4ab8e197ca30c03726b675ae7cce6ac9d6622e"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+RDEPENDS:${PN} += " \
+    python3 \
+    rapidjson \
+"

--- a/recipes-devtools/triton/triton-client/0001-fix-cmake-build.patch
+++ b/recipes-devtools/triton/triton-client/0001-fix-cmake-build.patch
@@ -1,27 +1,23 @@
-From d0368d2f5ddcaba6eabd4729236ed2743a161ea6 Mon Sep 17 00:00:00 2001
+From 815e22afcdf70ab6756f4e47f4b4a74d9d566d44 Mon Sep 17 00:00:00 2001
 From: Roger Knecht <roger@norberthealth.com>
 Date: Thu, 23 Jun 2022 17:09:28 +0200
 Subject: [PATCH] fix cmake build
 
 ---
- CMakeLists.txt                 | 14 +++-----------
- src/c++/CMakeLists.txt         | 24 +++++-------------------
- src/c++/library/CMakeLists.txt | 16 ++++------------
- 3 files changed, 12 insertions(+), 42 deletions(-)
+ CMakeLists.txt                                | 14 ++++--------
+ src/c++/CMakeLists.txt                        | 22 ++++---------------
+ src/c++/library/CMakeLists.txt                | 14 +++---------
+ src/c++/perf_analyzer/CMakeLists.txt          |  2 +-
+ .../client_backend/triton/CMakeLists.txt      |  2 +-
+ src/python/CMakeLists.txt                     | 20 ++++-------------
+ src/python/library/build_wheel.py             |  1 +
+ .../library/tritonclient/utils/CMakeLists.txt |  6 ++---
+ 8 files changed, 21 insertions(+), 60 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d25043c..20c10df 100644
+index d25043c..3e272a0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -24,7 +24,7 @@
- # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
--cmake_minimum_required(VERSION 3.17)
-+cmake_minimum_required(VERSION 3.16)
- 
- project(tritonclient LANGUAGES C CXX)
- 
 @@ -60,16 +60,7 @@ endif()
  #
  # Dependencies
@@ -49,19 +45,20 @@ index d25043c..20c10df 100644
    )
  endif() # TRITON_ENABLE_CC_HTTP OR TRITON_ENABLE_CC_GRPC OR TRITON_ENABLE_PERF_ANALYZER
  
+@@ -204,7 +196,9 @@ if(TRITON_ENABLE_PYTHON_HTTP OR TRITON_ENABLE_PYTHON_GRPC)
+       -DTRITON_ENABLE_GPU:BOOL=${TRITON_ENABLE_GPU}
+       -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+       -DCMAKE_INSTALL_PREFIX:PATH=${TRITON_INSTALL_PREFIX}
++      -DCUDA_TOOLKIT_ROOT_DIR:PATH=${CUDA_TOOLKIT_ROOT_DIR}
+     DEPENDS ${_py_client_depends}
++    INSTALL_COMMAND ""
+   )
+ endif() # TRITON_ENABLE_PYTHON_HTTP OR TRITON_ENABLE_PYTHON_GRPC
+ 
 diff --git a/src/c++/CMakeLists.txt b/src/c++/CMakeLists.txt
-index a641fcb..dc13fa3 100644
+index a641fcb..6c2d7ec 100644
 --- a/src/c++/CMakeLists.txt
 +++ b/src/c++/CMakeLists.txt
-@@ -24,7 +24,7 @@
- # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
--cmake_minimum_required(VERSION 3.17)
-+cmake_minimum_required(VERSION 3.16)
- 
- project(cc-clients LANGUAGES C CXX)
- 
 @@ -50,27 +50,12 @@ endif()
  #
  # Dependencies
@@ -109,18 +106,9 @@ index a641fcb..dc13fa3 100644
  
  #
 diff --git a/src/c++/library/CMakeLists.txt b/src/c++/library/CMakeLists.txt
-index e0eed14..ad47a7b 100644
+index e0eed14..2cf0371 100644
 --- a/src/c++/library/CMakeLists.txt
 +++ b/src/c++/library/CMakeLists.txt
-@@ -24,7 +24,7 @@
- # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
--cmake_minimum_required (VERSION 3.18)
-+cmake_minimum_required (VERSION 3.16)
- 
- find_package(Threads REQUIRED)
- set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 @@ -190,7 +190,7 @@ if(TRITON_ENABLE_CC_GRPC OR TRITON_ENABLE_PERF_ANALYZER)
      if(TRITON_ENABLE_GPU)
        target_link_libraries(
@@ -175,6 +163,101 @@ index e0eed14..ad47a7b 100644
        )
      endif() # TRITON_ENABLE_GPU
    endforeach()
--- 
-2.17.1
-
+diff --git a/src/c++/perf_analyzer/CMakeLists.txt b/src/c++/perf_analyzer/CMakeLists.txt
+index 3682d32..b446dd8 100644
+--- a/src/c++/perf_analyzer/CMakeLists.txt
++++ b/src/c++/perf_analyzer/CMakeLists.txt
+@@ -88,7 +88,7 @@ if(TRITON_ENABLE_GPU)
+ 
+   target_link_libraries(
+     perf_analyzer
+-    PRIVATE CUDA::cudart
++    PRIVATE cudart
+   )
+ endif()
+ 
+diff --git a/src/c++/perf_analyzer/client_backend/triton/CMakeLists.txt b/src/c++/perf_analyzer/client_backend/triton/CMakeLists.txt
+index cdb7410..e631785 100644
+--- a/src/c++/perf_analyzer/client_backend/triton/CMakeLists.txt
++++ b/src/c++/perf_analyzer/client_backend/triton/CMakeLists.txt
+@@ -51,6 +51,6 @@ target_link_libraries(
+ if(${TRITON_ENABLE_GPU})
+   target_link_libraries(
+     triton-client-backend-library
+-    PRIVATE CUDA::cudart
++    PRIVATE cudart
+   )
+ endif() # TRITON_ENABLE_GPU
+diff --git a/src/python/CMakeLists.txt b/src/python/CMakeLists.txt
+index 444df2c..33a385f 100644
+--- a/src/python/CMakeLists.txt
++++ b/src/python/CMakeLists.txt
+@@ -48,27 +48,15 @@ endif()
+ #
+ # Dependencies
+ #
+-include(FetchContent)
+-
+-FetchContent_Declare(
+-  repo-common
+-  GIT_REPOSITORY https://github.com/triton-inference-server/common.git
+-  GIT_TAG ${TRITON_COMMON_REPO_TAG}
+-  GIT_SHALLOW ON
+-)
+-
+-if(TRITON_ENABLE_PYTHON_GRPC)
+-  set(TRITON_COMMON_ENABLE_PROTOBUF ON)
+-  set(TRITON_COMMON_ENABLE_GRPC ON)
+-endif() # TRITON_ENABLE_PYTHON_GRPC
+-
+-FetchContent_MakeAvailable(repo-common)
+ 
+ #
+ # CUDA
+ #
+ if(${TRITON_ENABLE_GPU})
+-  find_package(CUDAToolkit REQUIRED)
++  enable_language(CUDA)
++  find_package(CUDA REQUIRED)
++  include_directories(${CUDA_INCLUDE_DIRS})
++  link_directories(${CUDA_LIBRARIES})
+ endif() # TRITON_ENABLE_GPU
+ 
+ #
+diff --git a/src/python/library/build_wheel.py b/src/python/library/build_wheel.py
+index 442d6fe..3b975e8 100644
+--- a/src/python/library/build_wheel.py
++++ b/src/python/library/build_wheel.py
+@@ -31,6 +31,7 @@ import pathlib
+ import re
+ import shutil
+ import subprocess
++import sys
+ from distutils.dir_util import copy_tree
+ from tempfile import mkstemp
+ 
+diff --git a/src/python/library/tritonclient/utils/CMakeLists.txt b/src/python/library/tritonclient/utils/CMakeLists.txt
+index 98e9d19..7b74672 100644
+--- a/src/python/library/tritonclient/utils/CMakeLists.txt
++++ b/src/python/library/tritonclient/utils/CMakeLists.txt
+@@ -35,9 +35,9 @@ if(NOT WIN32)
+   add_library(cshm SHARED shared_memory/shared_memory.cc)
+   if(${TRITON_ENABLE_GPU})
+     target_compile_definitions(cshm PUBLIC TRITON_ENABLE_GPU=1)
+-    target_link_libraries(cshm PUBLIC CUDA::cudart)
++    target_link_libraries(cshm INTERFACE cudart)
+   endif() # TRITON_ENABLE_GPU
+-  target_link_libraries(cshm PRIVATE rt)
++  target_link_libraries(cshm INTERFACE rt)
+ 
+   #
+   # libccudashm.so
+@@ -52,7 +52,7 @@ if(NOT WIN32)
+     )
+     target_include_directories(ccudashm PUBLIC ${CUDA_INCLUDE_DIRS})
+     target_compile_definitions(ccudashm PUBLIC TRITON_ENABLE_GPU=1)
+-    target_link_libraries(ccudashm PUBLIC CUDA::cudart)
++    target_link_libraries(ccudashm PUBLIC cudart)
+   endif() # TRITON_ENABLE_GPU
+ endif() # WIN32
+ 

--- a/recipes-devtools/triton/triton-client_r22.05.bb
+++ b/recipes-devtools/triton/triton-client_r22.05.bb
@@ -19,30 +19,44 @@ DEPENDS = "\
 
 COMPATIBLE_MACHINE = "(cuda)"
 
-inherit cmake cuda
+inherit pkgconfig cmake python3-dir cuda
 
-EXTRA_OECMAKE = "\
-    -DTRITON_ENABLE_TESTS=OFF \
-    -DTRITON_ENABLE_GPU=OFF \
+EXTRA_OECMAKE += "\
     -DCMAKE_INSTALL_PREFIX=${D}/usr \
 "
 
-PACKAGECONFIG ??= "cc_http gpu"
+PACKAGECONFIG ??= "cc_http gpu python_http"
 PACKAGECONFIG[cc_http] = "-DTRITON_ENABLE_CC_HTTP=ON,-DTRITON_ENABLE_CC_HTTP=OFF,curl"
 PACKAGECONFIG[cc_grpc] = "-DTRITON_ENABLE_CC_GRPC=ON,-DTRITON_ENABLE_CC_GRPC=OFF,grpc protobuf protobuf-native"
-PACKAGECONFIG[python_http] = "-DTRITON_ENABLE_PYTHON_HTTP=ON,-DTRITON_ENABLE_PYTHON_HTTP=OFF"
-PACKAGECONFIG[python_grpc] = "-DTRITON_ENABLE_PYTHON_GRPC=ON,-DTRITON_ENABLE_PYTHON_GRPC=OFF"
+PACKAGECONFIG[python_http] = "-DTRITON_ENABLE_PYTHON_HTTP=ON,-DTRITON_ENABLE_PYTHON_HTTP=OFF,,triton-python-backend"
+PACKAGECONFIG[python_grpc] = "-DTRITON_ENABLE_PYTHON_GRPC=ON,-DTRITON_ENABLE_PYTHON_GRPC=OFF,,triton-python-backend"
 PACKAGECONFIG[java] = "-DTRITON_ENABLE_JAVA_HTTP=ON,-DTRITON_ENABLE_JAVA_HTTP=OFF"
 PACKAGECONFIG[perf] = "-DTRITON_ENABLE_PERF_ANALYZER=ON,-DTRITON_ENABLE_PERF_ANALYZER=OFF"
 PACKAGECONFIG[perf_c] = "-DTRITON_ENABLE_PERF_ANALYZER_C_API=ON,-DTRITON_ENABLE_PERF_ANALYZER_C_API=OFF"
 PACKAGECONFIG[perf_tfs] = "-DTRITON_ENABLE_PERF_ANALYZER_TFS=ON,-DTRITON_ENABLE_PERF_ANALYZER_TFS=OFF"
 PACKAGECONFIG[perf_ts] = "-DTRITON_ENABLE_PERF_ANALYZER_TS=ON,-DTRITON_ENABLE_PERF_ANALYZER_TS=OFF"
 PACKAGECONFIG[gpu] = "-DTRITON_ENABLE_GPU=ON,-DTRITON_ENABLE_GPU=OFF,cuda-cudart"
+PACKAGECONFIG[tests] = "-DTRITON_ENABLE_TESTS=ON,-DTRITON_ENABLE_TESTS=OFF"
+PACKAGECONFIG[examples] = "-DTRITON_ENABLE_EXAMPLES=ON,-DTRITON_ENABLE_EXAMPLES=OFF"
+
+python set_epoch() {
+    # workaround: Set epoch to 1980/1/1 to fix build error "ZIP does not support timestamps before 1980"
+    d.setVar('SOURCE_DATE_EPOCH', '315532800')
+}
+
+do_compile[prefuncs] += " set_epoch"
 
 do_install() {
     DESTDIR='${D}' eval ${DESTDIR:+DESTDIR=${DESTDIR} }${CMAKE_VERBOSE} cmake --build '${B}/cc-clients' "$@"  --target ${OECMAKE_TARGET_INSTALL} -- ${EXTRA_OECMAKE_BUILD}
-    install -d ${D}/${includedir}/triton
-    mv ${D}${includedir}/*.h ${D}/${includedir}/triton
+    install -d ${D}${includedir}/triton
+    mv ${D}${includedir}/*.h ${D}${includedir}/triton
     mv ${D}${libdir}/libhttpclient.so ${D}${libdir}/libhttpclient.so.${PV}
     ln -sr ${D}${libdir}/libhttpclient.so.${PV} ${D}${libdir}/libhttpclient.so
+
+    install -d ${D}${PYTHON_SITEPACKAGES_DIR}
+    cp --preserve=mode,timestamps --recursive ${B}/python-clients/library/linux/wheel/build/lib/* ${D}${PYTHON_SITEPACKAGES_DIR}
 }
+
+FILES:${PN} += " \
+    ${PYTHON_SITEPACKAGES_DIR} \
+"

--- a/recipes-devtools/triton/triton-python-backend/0001-fix-cmake-build.patch
+++ b/recipes-devtools/triton/triton-python-backend/0001-fix-cmake-build.patch
@@ -1,0 +1,240 @@
+From f15068b197d56b2ee9ac1700b13f91a1bfedca11 Mon Sep 17 00:00:00 2001
+From: Roger Knecht <roger@norberthealth.com>
+Date: Fri, 21 Oct 2022 11:59:50 +0200
+Subject: [PATCH] fix cmake build
+
+---
+ CMakeLists.txt    | 111 ++++------------------------------------------
+ src/pb_memory.h   |   2 +
+ src/python.cc     |   4 +-
+ src/shm_manager.h |   1 +
+ 4 files changed, 14 insertions(+), 104 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e1ea996..4c41736 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -26,7 +26,7 @@
+ 
+ cmake_minimum_required(VERSION 3.17)
+ 
+-project(tritonpythonbackend LANGUAGES C CXX)
++project(triton-python-backend LANGUAGES C CXX)
+ 
+ #
+ # Options
+@@ -45,71 +45,14 @@ set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/co
+ #
+ # Dependencies
+ #
+-# FetchContent's composibility isn't very good. We must include the
+-# transitive closure of all repos so that we can override the tag.
+-#
+-include(FetchContent)
+-
+-# We need to use ExternalProject because we want to use Boost 1.76 which is not
+-# available in Ubuntu 20.04
+-include(ExternalProject)
+-
+-FetchContent_Declare(
+-  repo-common
+-  GIT_REPOSITORY https://github.com/triton-inference-server/common.git
+-  GIT_TAG ${TRITON_COMMON_REPO_TAG}
+-)
+-FetchContent_Declare(
+-  repo-core
+-  GIT_REPOSITORY https://github.com/triton-inference-server/core.git
+-  GIT_TAG ${TRITON_CORE_REPO_TAG}
+-)
+-FetchContent_Declare(
+-  repo-backend
+-  GIT_REPOSITORY https://github.com/triton-inference-server/backend.git
+-  GIT_TAG ${TRITON_BACKEND_REPO_TAG}
+-)
+-FetchContent_MakeAvailable(repo-common repo-core repo-backend)
+-
+-FetchContent_Declare(
+-  pybind11
+-  GIT_REPOSITORY "https://github.com/pybind/pybind11"
+-  GIT_TAG "v2.6"
+-  GIT_SHALLOW ON
+-)
+-FetchContent_MakeAvailable(pybind11)
+-
+-#
+-# DLPack
+-#
+-FetchContent_Declare(
+-  dlpack
+-  GIT_REPOSITORY "https://github.com/dmlc/dlpack"
+-  GIT_TAG "v0.5"
+-  GIT_SHALLOW ON
+-)
+-FetchContent_MakeAvailable(dlpack)
+-
+-#
+-# Boost
+-#
+-ExternalProject_Add(
+-  boostorg
+-  URL https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz
+-  URL_HASH SHA256=7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca
+-  PREFIX "boost-src"
+-  CONFIGURE_COMMAND ${CMAKE_COMMAND} -E copy_directory
+-                    <SOURCE_DIR>/boost/ ${CMAKE_BINARY_DIR}/boost
+-  INSTALL_COMMAND ""
+-  BUILD_COMMAND ""
+-)
+-set(boostorg_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/boost/")
+ 
+ #
+ # CUDA
+ #
+ if(${TRITON_ENABLE_GPU})
+-  find_package(CUDAToolkit REQUIRED)
++  enable_language(CUDA)
++  find_package(CUDA REQUIRED)
++  include_directories(${CUDA_INCLUDE_DIRS})
+   message(STATUS "Using CUDA ${CUDA_VERSION}")
+   set(CUDA_NVCC_FLAGS -std=c++11)
+ elseif()
+@@ -192,16 +135,6 @@ list(APPEND
+   ${COMMON_SRCS}
+ )
+ 
+-add_executable(
+-  triton-python-backend-stub
+-  ${PYTHNON_BACKEND_STUB_SRCS}
+-)
+-
+-add_dependencies(triton-python-backend boostorg)
+-add_dependencies(triton-python-backend-stub boostorg)
+-
+-set_property(TARGET triton-python-backend-stub PROPERTY OUTPUT_NAME triton_python_backend_stub)
+-
+ add_library(
+   TritonPythonBackend::triton-python-backend ALIAS triton-python-backend
+ )
+@@ -213,39 +146,17 @@ target_compile_options(
+     -Wall -Wextra -Wno-unused-parameter -Wno-type-limits -Werror>
+ )
+ 
+-target_compile_features(triton-python-backend-stub PRIVATE cxx_std_11)
+-target_compile_options(
+-  triton-python-backend-stub PRIVATE
+-  $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+-  -fvisibility=hidden -Wall -Wextra -Wno-unused-parameter -Wno-type-limits -Werror>
+-)
+-target_compile_definitions(triton-python-backend-stub PRIVATE TRITON_PB_STUB)
+-
+ target_link_libraries(
+   triton-python-backend
+   PRIVATE
+-    dlpack
+     Threads::Threads
+     triton-backend-utils          # from repo-backend
+     -ldl                          # dlopen
+-    -lrt                          # shared memory 
+-    triton-core-serverstub        # from repo-core
++    -lrt                          # shared memory
+     ZLIB::ZLIB
+     -larchive
+ )
+ 
+-target_link_libraries(
+-  triton-python-backend-stub
+-  PRIVATE
+-   dlpack
+-   Threads::Threads
+-   triton-backend-utils           # from repo-backend
+-   pybind11::embed
+-   dlpack
+-   -lrt                           # shared memory 
+-   -larchive                      # libarchive
+-)
+-
+ set_target_properties(
+   triton-python-backend PROPERTIES
+   POSITION_INDEPENDENT_CODE ON
+@@ -254,8 +165,6 @@ set_target_properties(
+   LINK_FLAGS "-Wl,--version-script libtriton_python.ldscript"
+ )
+ 
+-add_subdirectory(./src/shm_monitor)
+-
+ #
+ # Install
+ #
+@@ -265,12 +174,11 @@ set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/TritonPythonBackend)
+ install(
+   TARGETS
+     triton-python-backend
+-    triton-python-backend-stub
+   EXPORT
+     triton-python-backend-targets
+-  LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/backends/python
+-  ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/backends/python
+-  RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/backends/python
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+ )
+ 
+ install(
+@@ -287,8 +195,7 @@ install(
+ install(
+   FILES
+     src/resources/triton_python_backend_utils.py
+-  DESTINATION
+-    ${CMAKE_INSTALL_PREFIX}/backends/python
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+ )
+ 
+ include(CMakePackageConfigHelpers)
+diff --git a/src/pb_memory.h b/src/pb_memory.h
+index 61df776..55320f6 100644
+--- a/src/pb_memory.h
++++ b/src/pb_memory.h
+@@ -26,6 +26,8 @@
+ 
+ #pragma once
+ 
++#include <functional>
++
+ #include "pb_utils.h"
+ #include "shm_manager.h"
+ #include "triton/backend/backend_common.h"
+diff --git a/src/python.cc b/src/python.cc
+index 1a3fd46..27d64d0 100644
+--- a/src/python.cc
++++ b/src/python.cc
+@@ -1848,7 +1848,7 @@ ModelInstanceState::ProcessRequests(
+                 shm_pool_, actual_memory_type, actual_memory_type_id,
+                 0 /* byte size */, nullptr /* data ptr */));
+ 
+-        gpu_output_buffers.push_back({std::move(output_buffer), {buffer, r}});
++        gpu_output_buffers.push_back(std::move(std::pair<std::unique_ptr<PbMemory>, std::pair<void*, uint64_t>>(std::move(output_buffer), std::pair<void*, uint64_t>(buffer, r))));
+       }
+ 
+       if (src_memory_type != TRITONSERVER_MEMORY_GPU) {
+@@ -1984,7 +1984,7 @@ ModelInstanceState::~ModelInstanceState()
+       }
+ 
+       // Wait for all the futures to be finished.
+-      thread_pool_->wait();
++      thread_pool_->join();
+ 
+       ipc_message->Command() = PYTHONSTUB_FinalizeRequest;
+       stub_message_queue_->Push(ipc_message->ShmHandle());
+diff --git a/src/shm_manager.h b/src/shm_manager.h
+index 705d087..1db3f26 100644
+--- a/src/shm_manager.h
++++ b/src/shm_manager.h
+@@ -26,6 +26,7 @@
+ 
+ #pragma once
+ 
++#include <functional>
+ #include <sys/wait.h>
+ #include <boost/interprocess/allocators/allocator.hpp>
+ #include <boost/interprocess/detail/atomic.hpp>

--- a/recipes-devtools/triton/triton-python-backend_r22.05.bb
+++ b/recipes-devtools/triton/triton-python-backend_r22.05.bb
@@ -1,0 +1,47 @@
+DESCRIPTION = "Triton backend that enables pre-process, post-processing and other logic to be implemented in Python."
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=7889848dc86811b06ded7bfa9ba39e02"
+
+SRC_URI = "git://github.com/triton-inference-server/python_backend.git;protocol=https;branch=r22.05 \
+           file://0001-fix-cmake-build.patch \
+           "
+
+SRCREV = "6133572a4f090721cc52e79595b70f383397b186"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = " \
+    zlib \
+    libarchive \
+    boost \
+    dlpack \
+    triton-common \
+    triton-core \
+    triton-backend \
+"
+
+RDEPENDS:${PN} = " \
+    python3-pybind11 \
+    python3-gevent \
+    python3-geventhttpclient \
+    python3-rapidjson \
+"
+
+COMPATIBLE_MACHINE = "(cuda)"
+
+inherit cmake pkgconfig cuda
+
+PACKAGECONFIG ?= "gpu"
+PACKAGECONFIG[gpu] = "-DTRITON_ENABLE_GPU=ON,-DTRITON_ENABLE_GPU=OFF"
+PACKAGECONFIG[stats] = "-DTRITON_ENABLE_STATS=ON,-DTRITON_ENABLE_STATS=OFF"
+PACKAGECONFIG[nvtx] = "-DTRITON_ENABLE_NVTX=ON,-DTRITON_ENABLE_NVTX=OFF"
+
+do_install:append() {
+    mv ${D}${libdir}/libtriton_python.so ${D}${libdir}/libtriton_python.so.${PV}
+    ln -sr ${D}${libdir}/libtriton_python.so.${PV} ${D}${libdir}/libtriton_python.so
+}
+
+FILES:${PN} = " \
+    ${libdir}/triton_python_backend_utils.py \
+    ${libdir}/libtriton_python.so.${PV} \
+"


### PR DESCRIPTION
@ichergui Here is the master PR for the triton-client python bindings.

The changes are the same as in the `dunfell` branch except:
- the obvious adjustments for the new recipe syntax
- fixes for compiler issues in the `triton-python-backend` which were not present in `dunfell`.