### PR TITLE
recipes-devtools: python3-pycuda: Fix configure issue

### DIFF
--- a/recipes-devtools/python/python3-pycuda_2020.1.bb
+++ b/recipes-devtools/python/python3-pycuda_2020.1.bb
@@ -36,5 +36,4 @@ do_configure() {
     ${PYTHON_PN} -u ${S}/configure.py
     # disable CURAND otherwise cannot compile
     sed -i 's?CUDA_ENABLE_CURAND = True?CUDA_ENABLE_CURAND = False?g' ${B}/siteconf.py
-    cp ${B}/siteconf.py ${S}
 }


### PR DESCRIPTION
On kirkstone branch following is reported:
DEBUG: Python function extend_recipe_sysroot finished | DEBUG: Executing shell function do_configure
| cp: '/home/ubuntu/yocto/my-test-os/build/tmp/work/armv8a_tegra194-poky-linux/python3-pycuda/2020.1-r0/pycuda-2020.1/siteconf.py' and '/home/ubuntu/yocto/my-test-os/build/tmp/work/armv8a_tegra194-poky-linux/python3-pycuda/2020.1-r0/pycuda-2020.1/siteconf.py' are the same file

Fix it by remove redundant copy.

Signed-off-by: Marek Belisko <marek.belisko@open-nandra.com>