### PR TITLE
nvidia-docker-tests: Add support for r35.2.1

### DIFF
--- a/recipes-test/tegra-tests/nvidia-docker-tests/0002-Add-version-remap-script-support.patch
+++ b/recipes-test/tegra-tests/nvidia-docker-tests/0002-Add-version-remap-script-support.patch
@@ -1,0 +1,32 @@
+From b4773893af2e235b45462f3507d9fbc176cf6039 Mon Sep 17 00:00:00 2001
+From: Dan Walkes <danwalkes@trellis-logic.com>
+Date: Sun, 29 Jan 2023 12:57:05 -0700
+Subject: [PATCH] Add version remap script support
+
+Nice NGC doesn't include tags for every L4T revision,
+add support for a remap script which can remap L4T_VERSION
+to one which is supported by NGC.
+
+Signed-off-by: Dan Walkes <danwalkes@trellis-logic.com>
+---
+ scripts/docker_test_ml.sh | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/scripts/docker_test_ml.sh b/scripts/docker_test_ml.sh
+index 3c7513e..83f3edf 100755
+--- a/scripts/docker_test_ml.sh
++++ b/scripts/docker_test_ml.sh
+@@ -3,6 +3,10 @@
+ set -e
+ source scripts/l4t_version.sh
+ 
++if [ -e scripts/l4t_version_remap.sh ]; then
++        source scripts/l4t_version_remap.sh
++fi
++
+ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ TEST_MOUNT="$ROOT/../test:/test"
+ CONTAINERS=${1:-"all"}
+-- 
+2.34.1
+

--- a/recipes-test/tegra-tests/nvidia-docker-tests/l4t_version_remap.sh.in
+++ b/recipes-test/tegra-tests/nvidia-docker-tests/l4t_version_remap.sh.in
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Historically NVIDIA does not re-tag containers in NVIDIA NGC to match latest versions of L4T.
+# This means matching the version of L4T running on the device is not sufficient to find the matching
+# containers on NVIDIA NGC.
+# This script remaps the L4T_VERSION value to match the availability of containers on nvidia ngc
+# as understood at build time and prints a message when the L4T_VERSION is overridden.
+# It should be called after L4T_VERSION is defined in an environment variable through l4t_version.sh
+# or similar mechanism
+
+if [ -z "${L4T_VERSION}" ]; then
+    echo "Please use l4t_version.sh to define an L4T version before sourcing this script"
+    exit 1
+fi
+
+check_remap() {
+    declare -A l4t_version_remap
+
+    # Build this array based on available tags in
+    #       https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-ml
+    #       https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-tensorflow
+    #       https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-pytorch
+    l4t_version_remap["35.2.1"]="35.1.0"
+    l4t_version_remap["32.7.2"]="32.7.1"
+    l4t_version_remap["32.7.3"]="32.7.1"
+
+    if [ "${l4t_version_remap[${L4T_VERSION}]+test}" ]; then
+            L4T_VERSION_ACTUAL=${L4T_VERSION}
+            L4T_VERSION=${l4t_version_remap[${L4T_VERSION}]}
+            echo "Overriding L4T_VERSION ${L4T_VERSION_ACTUAL} with version ${L4T_VERSION} to match container availability on NGC"
+    else
+            echo "No remap necessary for l4t version ${L4T_VERSION}"
+    fi
+}
+
+check_remap

--- a/recipes-test/tegra-tests/nvidia-docker-tests_1.0.bb
+++ b/recipes-test/tegra-tests/nvidia-docker-tests_1.0.bb
@@ -5,12 +5,14 @@ LIC_FILES_CHKSUM = "file://LICENSE.md;md5=da33f1c12f6d31e71cd114d0c336d4be"
 SRC_REPO ?= "github.com/dusty-nv/jetson-containers"
 SRCBRANCH ?= "master"
 SRC_URI = "git://${SRC_REPO};branch=${SRCBRANCH};protocol=https"
-SRCREV = "39496f8eba51ababb0cfb625fc70410163e4fe43"
+SRCREV = "bb17dc7db1ce46bb29e79ef0ac4e13aa934adf31"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI += "\
-        file://0001-Distro-agnostic-support-for-Test-ML-script.patch \
-	file://run-docker-tests.sh.in \
+    file://0001-Distro-agnostic-support-for-Test-ML-script.patch \
+    file://0002-Add-version-remap-script-support.patch \
+    file://l4t_version_remap.sh.in \
+    file://run-docker-tests.sh.in \
 "
 
 COMPATIBLE_MACHINE = "(tegra)"
@@ -32,14 +34,15 @@ do_install() {
 
     install -d ${D}${bindir}
     install -m 0755 ${WORKDIR}/run-docker-tests.sh.in ${D}${bindir}/run-docker-tests
+    install -m 0755 ${WORKDIR}/l4t_version_remap.sh.in ${D}/opt/nvidia-docker-tests/scripts/l4t_version_remap.sh
 }
 
 FILES:${PN} = " \
-                /opt/nvidia-docker-tests \
-		${bindir}/run-docker-tests \
-	      "
+    /opt/nvidia-docker-tests \
+    ${bindir}/run-docker-tests \
+"
 RDEPENDS:${PN} = " \
-                   bash \
-                   nvidia-docker \
-		   nv-tegra-release \
-		   "
+    bash \
+    nvidia-docker \
+    nv-tegra-release \
+"

--- a/recipes-test/tegra-tests/nvidia-docker-tests_1.0.bb
+++ b/recipes-test/tegra-tests/nvidia-docker-tests_1.0.bb
@@ -29,6 +29,9 @@ do_install() {
     for i in $(ls ${S}/test/*.py); do
         install ${i} ${D}/opt/nvidia-docker-tests/test
     done
+    for i in $(ls ${S}/test/*.sh); do
+        install -m 0755 ${i} ${D}/opt/nvidia-docker-tests/test
+    done
     install -d ${D}/opt/nvidia-docker-tests/test/data
     install -m 0644 ${S}/test/data/test_0.jpg ${D}/opt/nvidia-docker-tests/test/data
 


### PR DESCRIPTION
* Add support for an l4t_version_remap script which can
remap the L4T_VERSION environment variable to match containers
which actually exist in NGC.
* Go to latest upstream
* Fix some space/tab inconsistencies in the recipe.
* Add necessary test scripts to the rootfs