### PR TITLE
Updates for deepstream 6.2

### DIFF
--- a/recipes-devtools/deepstream/deepstream-6.2-pyds/0001-Fixes-for-cross-building.patch
+++ b/recipes-devtools/deepstream/deepstream-6.2-pyds/0001-Fixes-for-cross-building.patch
@@ -1,20 +1,20 @@
-From f37fdaf0b8b8a0b404ec0af379fee87eeb874392 Mon Sep 17 00:00:00 2001
+From 9645ecafda0b311e0aa13580d4ba0fa9ca6fac3f Mon Sep 17 00:00:00 2001
 From: Ilies CHERGUI <ilies.chergui@gmail.com>
-Date: Fri, 3 Jun 2022 00:01:57 +0100
+Date: Sun, 5 Feb 2023 15:57:11 +0000
 Subject: [PATCH 1/2] Fixes for cross-building
 
-Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  bindings/CMakeLists.txt    | 67 ++++++++++++--------------------------
  bindings/include/pyds.hpp  |  4 +--
  bindings/include/utils.hpp |  2 +-
  3 files changed, 23 insertions(+), 50 deletions(-)
 
-Index: git/bindings/CMakeLists.txt
-===================================================================
---- git.orig/bindings/CMakeLists.txt
-+++ git/bindings/CMakeLists.txt
+diff --git a/bindings/CMakeLists.txt b/bindings/CMakeLists.txt
+index 043324d..a081111 100644
+--- a/bindings/CMakeLists.txt
++++ b/bindings/CMakeLists.txt
 @@ -13,7 +13,8 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
@@ -25,20 +25,23 @@ Index: git/bindings/CMakeLists.txt
  
  # Setting values not set by user
  function(check_variable_set variable_name default_value)
-@@ -23,9 +24,9 @@ function(check_variable_set variable_nam
+@@ -22,10 +23,11 @@ function(check_variable_set variable_name default_value)
+         endif()
  endfunction()
  
- check_variable_set(DS_VERSION 6.1)
 -check_variable_set(PYTHON_MAJOR_VERSION 3)
 -check_variable_set(PYTHON_MINOR_VERSION 8)
 -check_variable_set(PIP_PLATFORM linux_x86_64)
+-check_variable_set(DS_PATH "/opt/nvidia/deepstream/deepstream")
++check_variable_set(DS_VERSION 6.2)
 +find_package(Python MODULE REQUIRED COMPONENTS Development)
 +check_variable_set(PYTHON_MAJOR_VERSION ${Python_VERSION_MAJOR})
 +check_variable_set(PYTHON_MINOR_VERSION ${Python_VERSION_MINOR})
- check_variable_set(DS_PATH "/opt/nvidia/deepstream/deepstream-${DS_VERSION}")
++check_variable_set(DS_PATH "/opt/nvidia/deepstream/deepstream-${DS_VERSION}")
  
  
-@@ -37,23 +38,19 @@ macro(check_variable_allowed var_name va
+ # Checking values are allowed
+@@ -36,23 +38,19 @@ macro(check_variable_allowed var_name var_list)
  endmacro()
  set(PYTHON_MAJVERS_ALLOWED 3)
  check_variable_allowed(PYTHON_MAJOR_VERSION PYTHON_MAJVERS_ALLOWED)
@@ -55,7 +58,7 @@ Index: git/bindings/CMakeLists.txt
  
  # Setting python build versions
 -set(PYTHON_VERSION ${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION})
--set(PIP_WHEEL pyds-1.1.4-py3-none-${PIP_PLATFORM}.whl)
+-set(PIP_WHEEL pyds-1.1.6-py3-none-${PIP_PLATFORM}.whl)
 +set(PYTHON_VERSION ${Python_VERSION})
 +find_package(PkgConfig REQUIRED)
 +pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
@@ -67,7 +70,7 @@ Index: git/bindings/CMakeLists.txt
  add_compile_options(-Wall -Wextra -pedantic -O3)
  
  include_directories(
-@@ -61,13 +58,7 @@ include_directories(
+@@ -60,13 +58,7 @@ include_directories(
          ${DS_PATH}/sources/includes/
          include/bind
          include/nvds
@@ -82,7 +85,7 @@ Index: git/bindings/CMakeLists.txt
          )
  
  add_library(pyds SHARED src/pyds.cpp src/utils.cpp src/bindanalyticsmeta.cpp
-@@ -79,37 +70,17 @@ add_library(pyds SHARED src/pyds.cpp src
+@@ -78,37 +70,18 @@ add_library(pyds SHARED src/pyds.cpp src/utils.cpp src/bindanalyticsmeta.cpp
  set_target_properties(pyds PROPERTIES PREFIX "")
  set_target_properties(pyds PROPERTIES OUTPUT_NAME "pyds")
  
@@ -115,7 +118,7 @@ Index: git/bindings/CMakeLists.txt
 +foreach(nvds_lib nvds_osd nvds_meta nvds_infer nvdsgst_meta nvdsgst_helper)
          add_ds_lib(${nvds_lib})
  endforeach()
--
+ 
 -# Pip wheel build
 -add_custom_command(
 -        OUTPUT ${PIP_WHEEL}
@@ -127,10 +130,10 @@ Index: git/bindings/CMakeLists.txt
 -
 -add_custom_target(pip_wheel ALL DEPENDS ${PIP_WHEEL})
 +target_link_libraries(pyds nvbufsurface nvbufsurftransform)
-Index: git/bindings/include/pyds.hpp
-===================================================================
---- git.orig/bindings/include/pyds.hpp
-+++ git/bindings/include/pyds.hpp
+diff --git a/bindings/include/pyds.hpp b/bindings/include/pyds.hpp
+index 971b0b4..f0c656f 100644
+--- a/bindings/include/pyds.hpp
++++ b/bindings/include/pyds.hpp
 @@ -19,7 +19,7 @@
  
  #include <memory>
@@ -140,23 +143,26 @@ Index: git/bindings/include/pyds.hpp
  #include "pybind11/pybind11.h"
  #include "pybind11/cast.h"
  #include "pybind11/pytypes.h"
-@@ -53,4 +53,4 @@ namespace pydeepstream {
+@@ -52,4 +52,4 @@ namespace pydeepstream {
      // rewritting ""_a operator from pybind11 namespace and putting it into
      // pydeepstream namespace
      py::arg operator ""_a(const char *str, size_t len);
 -}
 \ No newline at end of file
 +}
-Index: git/bindings/include/utils.hpp
-===================================================================
---- git.orig/bindings/include/utils.hpp
-+++ git/bindings/include/utils.hpp
+diff --git a/bindings/include/utils.hpp b/bindings/include/utils.hpp
+index f713b9b..49d6cca 100644
+--- a/bindings/include/utils.hpp
++++ b/bindings/include/utils.hpp
 @@ -33,7 +33,7 @@
  #include <optional>
  #include <mutex>
  #include <pybind11/cast.h>
 -#include <pybind11.h>
 +#include <pybind11/pybind11.h>
- #include "../docstrings/pydocumentation.h"
  
  namespace py = pybind11;
+ 
+-- 
+2.25.1
+

--- a/recipes-devtools/deepstream/deepstream-6.2-pyds/0002-Allow-apps-to-be-run-from-other-working-directories.patch
+++ b/recipes-devtools/deepstream/deepstream-6.2-pyds/0002-Allow-apps-to-be-run-from-other-working-directories.patch
@@ -1,28 +1,28 @@
-From cd19e251679a8453228fc5c8fd1bd47cff431873 Mon Sep 17 00:00:00 2001
+From e3bd9dfeb3384fa1024d91896d000832fe0e6af2 Mon Sep 17 00:00:00 2001
 From: Ilies CHERGUI <ilies.chergui@gmail.com>
-Date: Fri, 3 Jun 2022 00:29:53 +0100
+Date: Sun, 5 Feb 2023 16:33:33 +0000
 Subject: [PATCH 2/2] Allow apps to be run from other working directories
 
-Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+Signed-off-by: Matt Madison <matt@madison.systems>
 ---
- apps/common/is_aarch_64.py                        |  4 ----
- apps/common/utils.py                              |  2 --
- .../deepstream_imagedata-multistream_redaction.py |  8 ++++----
- .../deepstream_imagedata-multistream.py           |  8 ++++----
- .../deepstream_nvdsanalytics.py                   | 11 ++++++-----
- .../deepstream-opticalflow.py                     |  3 ++-
- .../deepstream_test1_rtsp_in_rtsp_out.py          |  9 +++++----
- .../deepstream_segmentation.py                    |  6 +++---
- .../deepstream_ssd_parser.py                      | 11 ++++++-----
- .../deepstream_test1_rtsp_out.py                  |  6 +++---
- .../deepstream_test_1_usb.py                      |  7 ++++---
- apps/deepstream-test1/deepstream_test_1.py        |  7 ++++---
- apps/deepstream-test2/deepstream_test_2.py        | 15 ++++++++-------
- apps/deepstream-test3/deepstream_test_3.py        |  7 ++++---
- apps/deepstream-test4/deepstream_test_4.py        | 10 +++++-----
- .../deepstream_rt_src_add_del.py                  | 15 ++++++++-------
- 16 files changed, 66 insertions(+), 63 deletions(-)
+ apps/common/is_aarch_64.py                       |  4 ----
+ apps/common/utils.py                             |  2 --
+ ...deepstream_imagedata-multistream_redaction.py |  8 ++++----
+ .../deepstream_imagedata-multistream.py          |  7 ++++---
+ .../deepstream_nvdsanalytics.py                  | 11 ++++++-----
+ .../deepstream-opticalflow.py                    |  3 ++-
+ .../deepstream_test1_rtsp_in_rtsp_out.py         |  9 +++++----
+ .../deepstream_segmentation.py                   |  6 +++---
+ .../deepstream_ssd_parser.py                     | 11 ++++++-----
+ .../deepstream_test1_rtsp_out.py                 |  7 ++++---
+ .../deepstream_test_1_usb.py                     |  7 ++++---
+ apps/deepstream-test1/deepstream_test_1.py       |  7 ++++---
+ apps/deepstream-test2/deepstream_test_2.py       | 16 +++++++++-------
+ apps/deepstream-test3/deepstream_test_3.py       |  7 ++++---
+ apps/deepstream-test4/deepstream_test_4.py       | 10 +++++-----
+ .../deepstream_rt_src_add_del.py                 | 15 ++++++++-------
+ 16 files changed, 68 insertions(+), 62 deletions(-)
 
 diff --git a/apps/common/is_aarch_64.py b/apps/common/is_aarch_64.py
 index 26276c3..b287613 100644
@@ -53,7 +53,7 @@ index f0e9e17..de91166 100644
  def long_to_uint64(l):
      value = ctypes.c_uint64(l & 0xffffffffffffffff).value
 diff --git a/apps/deepstream-imagedata-multistream-redaction/deepstream_imagedata-multistream_redaction.py b/apps/deepstream-imagedata-multistream-redaction/deepstream_imagedata-multistream_redaction.py
-index 1814f25..ab7cfaf 100644
+index c4397d6..aaa15d1 100644
 --- a/apps/deepstream-imagedata-multistream-redaction/deepstream_imagedata-multistream_redaction.py
 +++ b/apps/deepstream-imagedata-multistream-redaction/deepstream_imagedata-multistream_redaction.py
 @@ -18,9 +18,9 @@
@@ -69,7 +69,7 @@ index 1814f25..ab7cfaf 100644
  import gi
  import configparser
  
-@@ -380,7 +380,7 @@ def main(uri_inputs,codec,bitrate ):
+@@ -386,7 +386,7 @@ def main(uri_inputs,codec,bitrate ):
      streammux.set_property('height', 1080)
      streammux.set_property('batch-size', number_sources)
      streammux.set_property('batched-push-timeout', 4000000)
@@ -79,14 +79,13 @@ index 1814f25..ab7cfaf 100644
      if (pgie_batch_size != number_sources):
          print("WARNING: Overriding infer-config batch-size", pgie_batch_size, " with number of sources ",
 diff --git a/apps/deepstream-imagedata-multistream/deepstream_imagedata-multistream.py b/apps/deepstream-imagedata-multistream/deepstream_imagedata-multistream.py
-index b8ef50d..800e152 100755
+index b1a2e93..957ab7d 100755
 --- a/apps/deepstream-imagedata-multistream/deepstream_imagedata-multistream.py
 +++ b/apps/deepstream-imagedata-multistream/deepstream_imagedata-multistream.py
-@@ -17,9 +17,9 @@
- # limitations under the License.
+@@ -18,8 +18,9 @@
  ################################################################################
  
--import sys
+ import sys
 -
 -sys.path.append('../')
 +import sys, os
@@ -95,7 +94,7 @@ index b8ef50d..800e152 100755
  import gi
  import configparser
  
-@@ -355,7 +355,7 @@ def main(args):
+@@ -362,7 +363,7 @@ def main(args):
      streammux.set_property('height', 1080)
      streammux.set_property('batch-size', number_sources)
      streammux.set_property('batched-push-timeout', 4000000)
@@ -105,7 +104,7 @@ index b8ef50d..800e152 100755
      if (pgie_batch_size != number_sources):
          print("WARNING: Overriding infer-config batch-size", pgie_batch_size, " with number of sources ",
 diff --git a/apps/deepstream-nvdsanalytics/deepstream_nvdsanalytics.py b/apps/deepstream-nvdsanalytics/deepstream_nvdsanalytics.py
-index 8dc7bb5..0310bcf 100755
+index 9bafdd5..aea65d4 100755
 --- a/apps/deepstream-nvdsanalytics/deepstream_nvdsanalytics.py
 +++ b/apps/deepstream-nvdsanalytics/deepstream_nvdsanalytics.py
 @@ -17,8 +17,9 @@
@@ -190,7 +189,7 @@ index 88fd89b..645cfff 100755
  
      pgie_batch_size = pgie.get_property("batch-size")
 diff --git a/apps/deepstream-segmentation/deepstream_segmentation.py b/apps/deepstream-segmentation/deepstream_segmentation.py
-index cc0b92d..85be8ec 100755
+index 19e1366..09fe9ac 100755
 --- a/apps/deepstream-segmentation/deepstream_segmentation.py
 +++ b/apps/deepstream-segmentation/deepstream_segmentation.py
 @@ -17,9 +17,9 @@
@@ -251,21 +250,22 @@ index 8f1db26..97d1239 100755
      print("Adding elements to Pipeline \n")
      pipeline.add(source)
 diff --git a/apps/deepstream-test1-rtsp-out/deepstream_test1_rtsp_out.py b/apps/deepstream-test1-rtsp-out/deepstream_test1_rtsp_out.py
-index 462c4f1..9925c41 100755
+index 462c4f1..773319d 100755
 --- a/apps/deepstream-test1-rtsp-out/deepstream_test1_rtsp_out.py
 +++ b/apps/deepstream-test1-rtsp-out/deepstream_test1_rtsp_out.py
-@@ -18,8 +18,8 @@
+@@ -18,8 +18,9 @@
  ################################################################################
  
  import argparse
 -import sys
 -sys.path.append('../')
++import sys, os
 +HERE = os.path.normpath(os.path.dirname(__file__))
 +sys.path.append(os.path.dirname(HERE))
  
  import gi
  gi.require_version('Gst', '1.0')
-@@ -221,7 +221,7 @@ def main(args):
+@@ -221,7 +222,7 @@ def main(args):
      streammux.set_property('batch-size', 1)
      streammux.set_property('batched-push-timeout', 4000000)
      
@@ -275,7 +275,7 @@ index 462c4f1..9925c41 100755
      print("Adding elements to Pipeline \n")
      pipeline.add(source)
 diff --git a/apps/deepstream-test1-usbcam/deepstream_test_1_usb.py b/apps/deepstream-test1-usbcam/deepstream_test_1_usb.py
-index 83fcda8..3a166c6 100755
+index 0f10ce3..6b9ecb0 100755
 --- a/apps/deepstream-test1-usbcam/deepstream_test_1_usb.py
 +++ b/apps/deepstream-test1-usbcam/deepstream_test_1_usb.py
 @@ -17,8 +17,9 @@
@@ -290,7 +290,7 @@ index 83fcda8..3a166c6 100755
  import gi
  gi.require_version('Gst', '1.0')
  from gi.repository import GLib, Gst
-@@ -211,7 +212,7 @@ def main(args):
+@@ -214,7 +215,7 @@ def main(args):
      streammux.set_property('height', 1080)
      streammux.set_property('batch-size', 1)
      streammux.set_property('batched-push-timeout', 4000000)
@@ -300,7 +300,7 @@ index 83fcda8..3a166c6 100755
      sink.set_property('sync', False)
  
 diff --git a/apps/deepstream-test1/deepstream_test_1.py b/apps/deepstream-test1/deepstream_test_1.py
-index 8d0e9e4..a4ea28a 100755
+index a03d326..d765c57 100755
 --- a/apps/deepstream-test1/deepstream_test_1.py
 +++ b/apps/deepstream-test1/deepstream_test_1.py
 @@ -17,8 +17,9 @@
@@ -312,20 +312,20 @@ index 8d0e9e4..a4ea28a 100755
 +import sys, os
 +HERE = os.path.normpath(os.path.dirname(__file__))
 +sys.path.append(os.path.dirname(HERE))
+ import os
  import gi
  gi.require_version('Gst', '1.0')
- from gi.repository import GLib, Gst
-@@ -194,7 +195,7 @@ def main(args):
-     streammux.set_property('height', 1080)
+@@ -198,7 +199,7 @@ def main(args):
+         streammux.set_property('batched-push-timeout', 4000000)
+     
      streammux.set_property('batch-size', 1)
-     streammux.set_property('batched-push-timeout', 4000000)
 -    pgie.set_property('config-file-path', "dstest1_pgie_config.txt")
 +    pgie.set_property('config-file-path', os.path.join(HERE, "dstest1_pgie_config.txt"))
  
      print("Adding elements to Pipeline \n")
      pipeline.add(source)
 diff --git a/apps/deepstream-test2/deepstream_test_2.py b/apps/deepstream-test2/deepstream_test_2.py
-index 8c686ea..8ab8644 100755
+index bcafbe2..44f60c1 100755
 --- a/apps/deepstream-test2/deepstream_test_2.py
 +++ b/apps/deepstream-test2/deepstream_test_2.py
 @@ -17,8 +17,9 @@
@@ -340,7 +340,7 @@ index 8c686ea..8ab8644 100755
  import platform
  import configparser
  
-@@ -254,14 +255,14 @@ def main(args):
+@@ -257,14 +258,15 @@ def main(args):
      streammux.set_property('batched-push-timeout', 4000000)
  
      #Set properties of pgie and sgie
@@ -352,6 +352,7 @@ index 8c686ea..8ab8644 100755
 +    sgie1.set_property('config-file-path', os.path.join(HERE, "dstest2_sgie1_config.txt"))
 +    sgie2.set_property('config-file-path', os.path.join(HERE, "dstest2_sgie2_config.txt"))
 +    sgie3.set_property('config-file-path', os.path.join(HERE, "dstest2_sgie3_config.txt"))
++
  
      #Set properties of tracker
      config = configparser.ConfigParser()
@@ -361,7 +362,7 @@ index 8c686ea..8ab8644 100755
  
      for key in config['tracker']:
 diff --git a/apps/deepstream-test3/deepstream_test_3.py b/apps/deepstream-test3/deepstream_test_3.py
-index edce707..e7c601c 100755
+index d81ec92..ee6914c 100755
 --- a/apps/deepstream-test3/deepstream_test_3.py
 +++ b/apps/deepstream-test3/deepstream_test_3.py
 @@ -17,8 +17,9 @@
@@ -376,7 +377,7 @@ index edce707..e7c601c 100755
  from pathlib import Path
  import gi
  import configparser
-@@ -318,7 +319,7 @@ def main(args, requested_pgie=None, config=None, disable_probe=False):
+@@ -328,7 +329,7 @@ def main(args, requested_pgie=None, config=None, disable_probe=False):
      elif requested_pgie == "nvinfer" and config != None:
          pgie.set_property('config-file-path', config)
      else:
@@ -386,7 +387,7 @@ index edce707..e7c601c 100755
      if(pgie_batch_size != number_sources):
          print("WARNING: Overriding infer-config batch-size",pgie_batch_size," with number of sources ", number_sources," \n")
 diff --git a/apps/deepstream-test4/deepstream_test_4.py b/apps/deepstream-test4/deepstream_test_4.py
-index d50450a..7342af1 100755
+index b22cc64..be33348 100755
 --- a/apps/deepstream-test4/deepstream_test_4.py
 +++ b/apps/deepstream-test4/deepstream_test_4.py
 @@ -17,9 +17,9 @@
@@ -414,7 +415,7 @@ index d50450a..7342af1 100755
  pgie_classes_str = ["Vehicle", "TwoWheeler", "Person", "Roadsign"]
  
 diff --git a/apps/runtime_source_add_delete/deepstream_rt_src_add_del.py b/apps/runtime_source_add_delete/deepstream_rt_src_add_del.py
-index 62cb715..5f59e66 100644
+index 991bd9a..4eee5bb 100644
 --- a/apps/runtime_source_add_delete/deepstream_rt_src_add_del.py
 +++ b/apps/runtime_source_add_delete/deepstream_rt_src_add_del.py
 @@ -17,8 +17,9 @@
@@ -448,5 +449,5 @@ index 62cb715..5f59e66 100644
  CONFIG_GPU_ID = "gpu-id"
  CONFIG_GROUP_TRACKER = "tracker"
 -- 
-2.32.0
+2.25.1
 

--- a/recipes-devtools/deepstream/deepstream-6.2-pyds_1.1.6.bb
+++ b/recipes-devtools/deepstream/deepstream-6.2-pyds_1.1.6.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "Python bindings for Deepstream-6.1"
+DESCRIPTION = "Python bindings for Deepstream-6.2"
 HOMEPAGE = "https://github.com/NVIDIA-AI-IOT/deepstream_python_apps"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7a01a47514ea2d404b8db41b6cfe6db0"
@@ -9,8 +9,8 @@ SRC_URI = "git://${SRC_REPO};branch=${SRCBRANCH} \
            file://0001-Fixes-for-cross-building.patch \
            file://0002-Allow-apps-to-be-run-from-other-working-directories.patch \
            "
-# v1.1.4 tag
-SRCREV = "f70dcc966d3a7db5389425d725f056a9a3899b84"
+# v1.1.6 tag
+SRCREV = "441b50da01779a2afacc60d40cd666d4bdde628e"
 
 #PV .= "+git${SRCPV}"
 
@@ -18,8 +18,8 @@ COMPATIBLE_MACHINE = "(tegra)"
 
 S = "${WORKDIR}/git"
 
-DEPENDS = "deepstream-6.1 python3-pybind11 gstreamer1.0-python gstreamer1.0 glib-2.0"
-DS_PATH = "/opt/nvidia/deepstream/deepstream-6.1"
+DEPENDS = "deepstream-6.2 python3-pybind11 gstreamer1.0-python gstreamer1.0 glib-2.0"
+DS_PATH = "/opt/nvidia/deepstream/deepstream-6.2"
 
 inherit setuptools3 cmake pkgconfig ptest
 
@@ -50,5 +50,5 @@ do_install() {
 PACKAGES += "${PN}-samples"
 RDEPENDS:${PN} = "python3-pygobject gstreamer1.0-python"
 FILES:${PN}-samples = "${DS_PATH}/sources/deepstream_python_apps"
-RDEPENDS:${PN}-samples = "${PN} deepstream-6.1-samples-data python3-opencv python3-numpy gobject-introspection"
+RDEPENDS:${PN}-samples = "${PN} deepstream-6.2-samples-data python3-opencv python3-numpy gobject-introspection"
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"

--- a/recipes-devtools/deepstream/deepstream-6.2_6.2.0-1.bb
+++ b/recipes-devtools/deepstream/deepstream-6.2_6.2.0-1.bb
@@ -2,16 +2,16 @@ DESCRIPTION = "NVIDIA Deepstream SDK"
 HOMEPAGE = "https://developer.nvidia.com/deepstream-sdk"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = " \
-    file://usr/share/doc/deepstream-6.1/copyright;md5=32b2256361779ec59211b3a698f24ce2 \
-    file://opt/nvidia/deepstream/deepstream-6.1/LICENSE.txt;md5=430d70b62dcd279de697edf2d7a8661e \
-    file://opt/nvidia/deepstream/deepstream-6.1/doc/nvidia-tegra/LICENSE.iothub_client;md5=4f8c6347a759d246b5f96281726b8611 \
-    file://opt/nvidia/deepstream/deepstream-6.1/doc/nvidia-tegra/LICENSE.nvds_amqp_protocol_adaptor;md5=8b4b651fa4090272b2e08e208140a658 \
+    file://usr/share/doc/deepstream-6.2/copyright;md5=6d940d04ee16883d3cb354fcf72498b2 \
+    file://opt/nvidia/deepstream/deepstream-6.2/LICENSE.txt;md5=2c2c89b896d6ff98d77ceec8d1a56082 \
+    file://opt/nvidia/deepstream/deepstream-6.2/doc/nvidia-tegra/LICENSE.iothub_client;md5=4f8c6347a759d246b5f96281726b8611 \
+    file://opt/nvidia/deepstream/deepstream-6.2/doc/nvidia-tegra/LICENSE.nvds_amqp_protocol_adaptor;md5=8b4b651fa4090272b2e08e208140a658 \
 "
 
 inherit l4t_deb_pkgfeed
 
 SRC_COMMON_DEBS = "${BPN}_${PV}_arm64.deb;subdir=${BPN}"
-SRC_URI[sha256sum] = "5d901325c9ddd8e8e90ce70bce1fb94fa1b6a4749e6d2f26b4f78e235c9658de"
+SRC_URI[sha256sum] = "0029fb3b4cad214e24844d9532703ef7809c097df9d92b0567dd8963e3a9dbd2"
 
 COMPATIBLE_MACHINE = "(tegra)"
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"
@@ -29,7 +29,7 @@ PACKAGECONFIG[realsense] = ""
 
 DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-rtsp-server \
     tensorrt-core tensorrt-plugins libnvvpi2 libcufft libcublas libnpp json-glib \
-    openssl111 tegra-libraries-multimedia yaml-cpp-060 mdns \
+    openssl111 tegra-libraries-multimedia yaml-cpp-060 mdns grpc protobuf \
 "
 # XXX--- see hack in do_install
 DEPENDS += "patchelf-native"
@@ -39,7 +39,7 @@ S = "${WORKDIR}/${BPN}"
 B = "${WORKDIR}/build"
 
 DEEPSTREAM_BASEDIR = "/opt/nvidia/deepstream"
-DEEPSTREAM_PATH = "${DEEPSTREAM_BASEDIR}/deepstream-6.1"
+DEEPSTREAM_PATH = "${DEEPSTREAM_BASEDIR}/deepstream-6.2"
 SYSROOT_DIRS += "${DEEPSTREAM_PATH}/lib/"
 
 do_configure() {
@@ -100,9 +100,16 @@ do_install() {
     patchelf --replace-needed libcufft.so libcufft.so.10 ${D}${DEEPSTREAM_PATH}/lib/libnvds_nvmultiobjecttracker.so
     patchelf --replace-needed libcublas.so libcublas.so.11 ${D}${DEEPSTREAM_PATH}/lib/libnvds_nvmultiobjecttracker.so
     patchelf --replace-needed libcufft.so libcufft.so.10 ${D}${DEEPSTREAM_PATH}/lib/libnvds_audiotransform.so
+    patchelf --replace-needed libgrpc++.so.1.38 libgrpc++.so.1.50 ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_tts.so
+    patchelf --replace-needed libgrpc++.so.1.38 libgrpc++.so.1.50 ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_asr_grpc.so
+    patchelf --replace-needed libprotobuf.so.3.15.8.0 libprotobuf.so.32 ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_asr_grpc.so
+    patchelf --replace-needed libprotobuf.so.3.15.8.0 libprotobuf.so.32 ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_tts.so
+    patchelf --replace-needed libprotobuf.so.3.15.8.0 libprotobuf.so.32 ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_audio_proto.so
+    patchelf --replace-needed libnppial.so libnppial.so.11 ${D}${DEEPSTREAM_PATH}/lib/libnvds_vpicanmatch.so
+    patchelf --replace-needed libnppist.so libnppist.so.11 ${D}${DEEPSTREAM_PATH}/lib/libnvds_vpicanmatch.so
     # ---XXX
     cd ${D}${DEEPSTREAM_BASEDIR}
-    ln -s deepstream-6.1 deepstream
+    ln -s deepstream-6.2 deepstream
     cd -
 }
 

--- a/recipes-test/tegra-tests/deepstream-tests/run-deepstream-tests.sh
+++ b/recipes-test/tegra-tests/deepstream-tests/run-deepstream-tests.sh
@@ -8,7 +8,7 @@
 # Some of these tests work better if you use jetson_clocks to
 # speed things up.
 
-DEEPSTREAM_PATH="/opt/nvidia/deepstream/deepstream-6.1"
+DEEPSTREAM_PATH="/opt/nvidia/deepstream/deepstream-6.2"
 SAMPLEROOT="${DEEPSTREAM_PATH}/sources/apps/sample_apps"
 PYSAMPLEROOT="${DEEPSTREAM_PATH}/sources/deepstream_python_apps/apps"
 STREAMS="${DEEPSTREAM_PATH}/samples/streams"

--- a/recipes-test/tegra-tests/deepstream-tests_1.0.bb
+++ b/recipes-test/tegra-tests/deepstream-tests_1.0.bb
@@ -17,9 +17,9 @@ do_install() {
 
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"
 RDEPENDS:${PN} = " \
-    deepstream-6.1 \
-    deepstream-6.1-samples \
-    deepstream-6.1-pyds \
-    deepstream-6.1-pyds-samples \
+    deepstream-6.2 \
+    deepstream-6.2-samples \
+    deepstream-6.2-pyds \
+    deepstream-6.2-pyds-samples \
     tegra-tools-jetson-clocks \
 "


### PR DESCRIPTION
* Tests were done by using `demo-image-full` image with `Jetson Xavier AGX` machine
*  add `deepstream-tests` recipe to your image
* After flashing , and device booting properly, run the script `run-deepstream-tests`
* Result
```
nvstreammux: Successfully handled EOS for source_id=0
Frame Number= 1437 Number of Objects= 14 Vehicle_count= 11 Person_count= 3
Frame Number= 1437 Number of Objects= 15 Vehicle_count= 13 Person_count= 2
Frame Number= 1438 Number of Objects= 16 Vehicle_count= 13 Person_count= 3
Frame Number= 1438 Number of Objects= 15 Vehicle_count= 12 Person_count= 3
Frame Number= 1439 Number of Objects= 14 Vehicle_count= 11 Person_count= 3
Frame Number= 1439 Number of Objects= 14 Vehicle_count= 11 Person_count= 3
Frame Number= 1440 Number of Objects= 13 Vehicle_count= 11 Person_count= 2
Frame Number= 1440 Number of Objects= 15 Vehicle_count= 12 Person_count= 3
nvstreammux: Successfully handled EOS for source_id=1
Frame Number= 1441 Number of Objects= 15 Vehicle_count= 12 Person_count= 3
Frame Number= 1441 Number of Objects= 0 Vehicle_count= 0 Person_count= 0
Frame Number= 1442 Number of Objects= 0 Vehicle_count= 0 Person_count= 0
End-of-stream
Exiting app

=== PASS:  py_deepstream_test3 ===
Tests run:     6
Tests passed:  6
Tests skipped: 0
Tests failed:  0
bash-5.2#
```