### PR TITLE
Kirkstone l4t r32.7.x - update openSSL to patch CVEs.

### DIFF
--- a/recipes-connectivity/openssl/openssl111_1.1.1u.bb
+++ b/recipes-connectivity/openssl/openssl111_1.1.1u.bb
@@ -23,7 +23,7 @@ SRC_URI:append:class-nativesdk = " \
            file://environment.d-openssl.sh \
            "
 
-SRC_URI[sha256sum] = "0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1"
+SRC_URI[sha256sum] = "e2f8d84b523eecd06c7be7626830370300fbcc15386bf5142d72758f6963ebc6"
 
 inherit lib_package multilib_header multilib_script ptest
 MULTILIB_SCRIPTS = "${PN}-bin:${bindir}/c_rehash"


### PR DESCRIPTION
Update openSSL 1.1.1l to 1.1.1u to patch the following CVEs : CVE-2022-1292, CVE-2022-2068, CVE-2022-0778, CVE-2022-4450, CVE-2023-0215, CVE-2023-0464, CVE-2023-0286, CVE-2021-4160, CVE-2022-4304, CVE-2022-2097, CVE-2023-0465, CVE-2023-0466.