### PR TITLE
openssh: remove bbappend

### DIFF
--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,3 +1,0 @@
-RRECOMMENDS:${PN}-sshd:remove:tegra = "rng-tools"
-RRECOMMENDS:${PN}-sshd:append:tegra = " haveged"
-PACKAGE_ARCH:tegra = "${TEGRA_PKGARCH}"


### PR DESCRIPTION
Per the commit message for 868dfb46d96a27ec9041cb902fb769330277257d in OE-Core, kernel support random numbers changed in v5.6 and later, and the RRECOMMENDS we were modifying no longer exists in the recipe.