### PR TITLE
openssh: remove bbappend

### DIFF
--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,3 +1,0 @@
-RRECOMMENDS:${PN}-sshd:remove:tegra210 = "rng-tools"
-RRECOMMENDS:${PN}-sshd:append:tegra210 = " haveged"
-PACKAGE_ARCH:tegra210 = "${TEGRA_PKGARCH}"


### PR DESCRIPTION
Commit 2ed579aa28194cf671e5d4f4c61dc38d05de4b0c in OE-Core removed the RRECOMMENDS settings in the openssh recipe. While the 4.9 kernel we use on the older Jetson platforms still needs an entropy generator, this bbappend is probably not the right place to specify that.