### PR TITLE
triton: update recipes

### DIFF
--- a/recipes-devtools/triton/triton-backend_2.22.0.bb
+++ b/recipes-devtools/triton/triton-backend_2.22.0.bb
@@ -21,6 +21,8 @@ COMPATIBLE_MACHINE = "(cuda)"
 
 inherit cmake cuda
 
+DEBUG_PREFIX_MAP:remove:class-target = "-fcanon-prefix-map"
+
 PACKAGECONFIG ??= "gpu"
 PACKAGECONFIG[gpu] = "-DTRITON_ENABLE_GPU=ON,-DTRITON_ENABLE_GPU=OFF"
 PACKAGECONFIG[mali_gpu] = "-DTRITON_ENABLE_MALI_GPU=ON,-DTRITON_ENABLE_MALI_GPU=OFF"

--- a/recipes-devtools/triton/triton-client/0001-Build-fixups.patch
+++ b/recipes-devtools/triton/triton-client/0001-Build-fixups.patch
@@ -1,6 +1,6 @@
-From 93143b18f84da42c04c644f8a3b0140131025962 Mon Sep 17 00:00:00 2001
+From 084c3ee9e1979a4d45806598a2ba139304546ab5 Mon Sep 17 00:00:00 2001
 From: Ilies CHERGUI <ilies.chergui@gmail.com>
-Date: Thu, 10 Nov 2022 20:38:37 +0000
+Date: Sat, 22 Jul 2023 15:44:29 +0100
 Subject: [PATCH] Build fixups
 
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
@@ -14,7 +14,8 @@ Signed-off-by: Roger Knecht <roger@norberthealth.com>
  src/python/CMakeLists.txt                     | 20 ++++-------------
  src/python/library/build_wheel.py             |  1 +
  .../library/tritonclient/utils/CMakeLists.txt |  6 ++---
- 8 files changed, 23 insertions(+), 62 deletions(-)
+ .../cuda_shared_memory/cuda_shared_memory.cc  |  1 +
+ 9 files changed, 24 insertions(+), 62 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index d25043c..3e272a0 100644
@@ -281,6 +282,18 @@ index 98e9d19..7b74672 100644
    endif() # TRITON_ENABLE_GPU
  endif() # WIN32
  
+diff --git a/src/python/library/tritonclient/utils/cuda_shared_memory/cuda_shared_memory.cc b/src/python/library/tritonclient/utils/cuda_shared_memory/cuda_shared_memory.cc
+index ea86e50..0efcc8a 100644
+--- a/src/python/library/tritonclient/utils/cuda_shared_memory/cuda_shared_memory.cc
++++ b/src/python/library/tritonclient/utils/cuda_shared_memory/cuda_shared_memory.cc
+@@ -29,6 +29,7 @@
+ #include <cuda_runtime_api.h>
+ #include <cstring>
+ #include <iostream>
++#include <cstdint>
+ #include "../shared_memory/shared_memory_handle.h"
+ 
+ extern "C" {
 -- 
 2.25.1
 

--- a/recipes-devtools/triton/triton-client_2.22.0.bb
+++ b/recipes-devtools/triton/triton-client_2.22.0.bb
@@ -21,6 +21,8 @@ COMPATIBLE_MACHINE = "(cuda)"
 
 inherit pkgconfig cmake python3-dir cuda
 
+DEBUG_PREFIX_MAP:remove:class-target = "-fcanon-prefix-map"
+
 EXTRA_OECMAKE += '\
     -DCMAKE_INSTALL_PREFIX="${D}${prefix}" \
 '

--- a/recipes-devtools/triton/triton-core_2.22.0.bb
+++ b/recipes-devtools/triton/triton-core_2.22.0.bb
@@ -25,6 +25,8 @@ COMPATIBLE_MACHINE = "(cuda)"
 
 inherit cmake cuda
 
+DEBUG_PREFIX_MAP:remove:class-target = "-fcanon-prefix-map"
+
 EXTRA_OECMAKE = "\
     -DTRITON_CORE_HEADERS_ONLY=OFF \
     -DCMAKE_CXX_FLAGS='${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized' \

--- a/recipes-devtools/triton/triton-python-backend_2.22.0.bb
+++ b/recipes-devtools/triton/triton-python-backend_2.22.0.bb
@@ -32,6 +32,8 @@ COMPATIBLE_MACHINE = "(cuda)"
 
 inherit cmake pkgconfig cuda
 
+DEBUG_PREFIX_MAP:remove:class-target = "-fcanon-prefix-map"
+
 PACKAGECONFIG ?= "gpu"
 PACKAGECONFIG[gpu] = "-DTRITON_ENABLE_GPU=ON,-DTRITON_ENABLE_GPU=OFF"
 PACKAGECONFIG[stats] = "-DTRITON_ENABLE_STATS=ON,-DTRITON_ENABLE_STATS=OFF"

--- a/recipes-devtools/triton/triton-server_2.22.0.bb
+++ b/recipes-devtools/triton/triton-server_2.22.0.bb
@@ -21,6 +21,8 @@ COMPATIBLE_MACHINE = "(cuda)"
 
 inherit pkgconfig cmake cuda
 
+DEBUG_PREFIX_MAP:remove:class-target = "-fcanon-prefix-map"
+
 EXTRA_OECMAKE:append = ' \
     -DCMAKE_INSTALL_PREFIX="${D}${prefix}" \
     -DCMAKE_PREFIX_PATH="${STAGING_LIBDIR}/cmake/libevhtp;${STAGING_LIBDIR}/cmake/re2" \

--- a/recipes-devtools/triton/triton-tensorrt-backend/0001-Build-fixups.patch
+++ b/recipes-devtools/triton/triton-tensorrt-backend/0001-Build-fixups.patch
@@ -1,16 +1,17 @@
-From d6cf2877451346883961dc861a6b43c54bcb5687 Mon Sep 17 00:00:00 2001
+From c98b0f5c0b01439fe05d40e02a7a368c079a68bc Mon Sep 17 00:00:00 2001
 From: Ilies CHERGUI <ilies.chergui@gmail.com>
-Date: Thu, 10 Nov 2022 14:40:03 +0000
-Subject: [PATCH] Build fixups
+Date: Sat, 22 Jul 2023 15:05:32 +0100
+Subject: [PATCH 1/2] Build fixups
 
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 Signed-off-by: Roger Knecht <roger@norberthealth.com>
 ---
- CMakeLists.txt | 35 ++++++++++++-----------------------
- 1 file changed, 12 insertions(+), 23 deletions(-)
+ CMakeLists.txt  | 35 ++++++++++++-----------------------
+ src/tensorrt.cc |  2 +-
+ 2 files changed, 13 insertions(+), 24 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1c67c22..e131a9a 100644
+index 5da6ecd..11ee8b0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -46,7 +46,7 @@ if(NOT CMAKE_BUILD_TYPE)
@@ -56,7 +57,7 @@ index 1c67c22..e131a9a 100644
    message(STATUS "Using CUDA ${CUDA_VERSION}")
    set(CUDA_NVCC_FLAGS -std=c++11)
  
-@@ -184,9 +168,14 @@ find_library(NVINFER_PLUGIN_LIBRARY NAMES nvinfer_plugin)
+@@ -178,9 +162,14 @@ find_library(NVINFER_PLUGIN_LIBRARY NAMES nvinfer_plugin)
  target_link_libraries(
    triton-tensorrt-backend
    PRIVATE
@@ -73,7 +74,7 @@ index 1c67c22..e131a9a 100644
      -lpthread
      ${NVINFER_LIBRARY}
      ${NVINFER_PLUGIN_LIBRARY}
-@@ -200,7 +189,7 @@ target_link_libraries(
+@@ -194,7 +183,7 @@ target_link_libraries(
  target_link_libraries(
      triton-tensorrt-backend
      PRIVATE
@@ -82,6 +83,19 @@ index 1c67c22..e131a9a 100644
  )
  
  
+diff --git a/src/tensorrt.cc b/src/tensorrt.cc
+index 65f62d3..736ef15 100644
+--- a/src/tensorrt.cc
++++ b/src/tensorrt.cc
+@@ -2553,7 +2553,7 @@ ModelInstanceState::ProcessResponse()
+ {
+   while (true) {
+     NVTX_RANGE(nvtx_, "ProcessResponse " + Name());
+-    auto payload = std::move(completion_queue_.Get());
++    auto payload = completion_queue_.Get();
+     if (payload.get() == nullptr) {
+       break;
+     }
 -- 
 2.25.1
 

--- a/recipes-devtools/triton/triton-tensorrt-backend/0002-add-support-for-kUINT8.patch
+++ b/recipes-devtools/triton/triton-tensorrt-backend/0002-add-support-for-kUINT8.patch
@@ -1,0 +1,66 @@
+From 4d4933137c23a54bc9058a973754a47b43a4d118 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ilies.chergui@gmail.com>
+Date: Sat, 22 Jul 2023 15:06:32 +0100
+Subject: [PATCH 2/2] add support for kUINT8
+
+Based on the following commit:
+https://github.com/triton-inference-server/tensorrt_backend/commit/114d0cd241eecb2ff78bb5ad4cdb4c138b2ef845
+
+Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+---
+ src/tensorrt_utils.cc | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/src/tensorrt_utils.cc b/src/tensorrt_utils.cc
+index b6ad3de..eaf9aaa 100644
+--- a/src/tensorrt_utils.cc
++++ b/src/tensorrt_utils.cc
+@@ -40,13 +40,15 @@ ConvertTrtTypeToDataType(nvinfer1::DataType trt_type)
+       return TRITONSERVER_TYPE_FP16;
+     case nvinfer1::DataType::kINT8:
+       return TRITONSERVER_TYPE_INT8;
++    case nvinfer1::DataType::kUINT8:
++      return TRITONSERVER_TYPE_UINT8;
+     case nvinfer1::DataType::kINT32:
+       return TRITONSERVER_TYPE_INT32;
+     case nvinfer1::DataType::kBOOL:
+       return TRITONSERVER_TYPE_BOOL;
++    default:
++      return TRITONSERVER_TYPE_INVALID;
+   }
+-
+-  return TRITONSERVER_TYPE_INVALID;
+ }
+ 
+ std::string
+@@ -59,13 +61,15 @@ ConvertTrtTypeToConfigDataType(nvinfer1::DataType trt_type)
+       return "TYPE_FP16";
+     case nvinfer1::DataType::kINT8:
+       return "TYPE_INT8";
++    case nvinfer1::DataType::kUINT8:
++      return "TYPE_UINT8";
+     case nvinfer1::DataType::kINT32:
+       return "TYPE_INT32";
+     case nvinfer1::DataType::kBOOL:
+       return "TYPE_BOOL";
++    default:
++      return "TYPE_INVALID";
+   }
+-
+-  return "TYPE_INVALID";
+ }
+ 
+ bool
+@@ -113,6 +117,9 @@ ConvertDataTypeToTrtType(const TRITONSERVER_DataType& dtype)
+     case TRITONSERVER_TYPE_INT8:
+       trt_type = nvinfer1::DataType::kINT8;
+       break;
++    case TRITONSERVER_TYPE_UINT8:
++      trt_type = nvinfer1::DataType::kUINT8;
++      break;
+     case TRITONSERVER_TYPE_INT32:
+       trt_type = nvinfer1::DataType::kINT32;
+       break;
+-- 
+2.25.1
+

--- a/recipes-devtools/triton/triton-tensorrt-backend_2.22.0.bb
+++ b/recipes-devtools/triton/triton-tensorrt-backend_2.22.0.bb
@@ -5,6 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=4e068ed5ea6f9bce3de86a872b056d93"
 SRC_URI = "\
     git://github.com/triton-inference-server/tensorrt_backend.git;protocol=https;branch=r22.05 \
     file://0001-Build-fixups.patch \
+    file://0002-add-support-for-kUINT8.patch \
 "
 
 SRCREV = "94bca597ccc3961cd137567578f9c392cff8c0eb"
@@ -23,6 +24,8 @@ DEPENDS = "\
 COMPATIBLE_MACHINE = "(cuda)"
 
 inherit cuda cmake
+
+DEBUG_PREFIX_MAP:remove:class-target = "-fcanon-prefix-map"
 
 PACKAGECONFIG ??= "gpu"
 PACKAGECONFIG[gpu] = "-DTRITON_ENABLE_GPU=ON,-DTRITON_ENABLE_GPU=OFF"


### PR DESCRIPTION
* This PR is dedicated to fix the issue #79 

* Tests were done on `jetson-agx-xavier-devkit` with image `demo-image-full`

* Add the following line in your `conf/local.conf`
```
CORE_IMAGE_BASE_INSTALL:append = " triton-client triton-core triton-server"
```

* Running `tritonserver` application 

```
root@jetson-agx-orin-devkit:~# /usr/bin/tritonserver --model-repository=./triton_model_repo --backend-directory=/usr/lib --backend-config=tensorrt,version=8.4.1 --min-supported-compute-capability=5.3 --http-address=0.0.0.0 --http-port=8000
I1127 22:41:41.037633 884 pinned_memory_manager.cc:240] Pinned memory pool is created at '0x203b8e000' with size 268435456
I1127 22:41:41.038173 884 cuda_memory_manager.cc:105] CUDA memory pool is created on device 0 with size 67108864
I1127 22:41:41.046317 884 model_repository_manager.cc:1191] loading: Segmentation_Semantic:1
I1127 22:41:41.147114 884 model_repository_manager.cc:1191] loading: Segmentation_Industrial:1
I1127 22:41:41.248056 884 model_repository_manager.cc:1191] loading: Secondary_CarColor:1
I1127 22:41:41.329350 884 tensorrt.cc:5294] TRITONBACKEND_Initialize: tensorrt
I1127 22:41:41.329821 884 tensorrt.cc:5304] Triton TRITONBACKEND API version: 1.9
I1127 22:41:41.330102 884 tensorrt.cc:5310] 'tensorrt' TRITONBACKEND API version: 1.9
I1127 22:41:41.331278 884 tensorrt.cc:5353] backend configuration:
{"cmdline":{"auto-complete-config":"false","backend-directory":"/usr/lib","min-compute-capability":"5.300000","version":"8.4.1","default-max-batch-size":"4"}}
```
