### PR TITLE
Updates for deepstream 6.3

### DIFF
--- a/recipes-devtools/deepstream/deepstream-6.3-pyds/0001-Fixes-for-cross-building.patch
+++ b/recipes-devtools/deepstream/deepstream-6.3-pyds/0001-Fixes-for-cross-building.patch
@@ -1,18 +1,18 @@
-From 9645ecafda0b311e0aa13580d4ba0fa9ca6fac3f Mon Sep 17 00:00:00 2001
+From 0853effb1b2ead74c2413e4b282233cd0f7b51f5 Mon Sep 17 00:00:00 2001
 From: Ilies CHERGUI <ilies.chergui@gmail.com>
-Date: Sun, 5 Feb 2023 15:57:11 +0000
+Date: Sun, 13 Aug 2023 19:07:16 +0100
 Subject: [PATCH 1/2] Fixes for cross-building
 
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
- bindings/CMakeLists.txt    | 67 ++++++++++++--------------------------
- bindings/include/pyds.hpp  |  4 +--
+ bindings/CMakeLists.txt    | 66 ++++++++++++--------------------------
+ bindings/include/pyds.hpp  |  2 +-
  bindings/include/utils.hpp |  2 +-
- 3 files changed, 23 insertions(+), 50 deletions(-)
+ 3 files changed, 22 insertions(+), 48 deletions(-)
 
 diff --git a/bindings/CMakeLists.txt b/bindings/CMakeLists.txt
-index 043324d..a081111 100644
+index d89d5e8..a482f25 100644
 --- a/bindings/CMakeLists.txt
 +++ b/bindings/CMakeLists.txt
 @@ -13,7 +13,8 @@
@@ -20,7 +20,7 @@ index 043324d..a081111 100644
  # limitations under the License.
  
 -cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
-+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 +project(pyds DESCRIPTION "Python bindings for Deepstream")
  
  # Setting values not set by user
@@ -33,7 +33,7 @@ index 043324d..a081111 100644
 -check_variable_set(PYTHON_MINOR_VERSION 8)
 -check_variable_set(PIP_PLATFORM linux_x86_64)
 -check_variable_set(DS_PATH "/opt/nvidia/deepstream/deepstream")
-+check_variable_set(DS_VERSION 6.2)
++check_variable_set(DS_VERSION 6.3)
 +find_package(Python MODULE REQUIRED COMPONENTS Development)
 +check_variable_set(PYTHON_MAJOR_VERSION ${Python_VERSION_MAJOR})
 +check_variable_set(PYTHON_MINOR_VERSION ${Python_VERSION_MINOR})
@@ -41,7 +41,7 @@ index 043324d..a081111 100644
  
  
  # Checking values are allowed
-@@ -36,23 +38,19 @@ macro(check_variable_allowed var_name var_list)
+@@ -36,23 +38,20 @@ macro(check_variable_allowed var_name var_list)
  endmacro()
  set(PYTHON_MAJVERS_ALLOWED 3)
  check_variable_allowed(PYTHON_MAJOR_VERSION PYTHON_MAJVERS_ALLOWED)
@@ -58,19 +58,19 @@ index 043324d..a081111 100644
  
  # Setting python build versions
 -set(PYTHON_VERSION ${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION})
--set(PIP_WHEEL pyds-1.1.6-py3-none-${PIP_PLATFORM}.whl)
+-set(PIP_WHEEL pyds-1.1.8-py3-none-${PIP_PLATFORM}.whl)
 +set(PYTHON_VERSION ${Python_VERSION})
 +find_package(PkgConfig REQUIRED)
 +pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
 +pkg_check_modules(GSTREAMER REQUIRED IMPORTED_TARGET gstreamer-1.0)
 +find_package(pybind11 REQUIRED)
  
--# Describing pyds build
+ # Describing pyds build
 -project(pyds DESCRIPTION "Python bindings for Deepstream")
  add_compile_options(-Wall -Wextra -pedantic -O3)
  
  include_directories(
-@@ -60,13 +58,7 @@ include_directories(
+@@ -60,13 +59,7 @@ include_directories(
          ${DS_PATH}/sources/includes/
          include/bind
          include/nvds
@@ -85,7 +85,7 @@ index 043324d..a081111 100644
          )
  
  add_library(pyds SHARED src/pyds.cpp src/utils.cpp src/bindanalyticsmeta.cpp
-@@ -78,37 +70,18 @@ add_library(pyds SHARED src/pyds.cpp src/utils.cpp src/bindanalyticsmeta.cpp
+@@ -78,37 +71,18 @@ add_library(pyds SHARED src/pyds.cpp src/utils.cpp src/bindanalyticsmeta.cpp
  set_target_properties(pyds PROPERTIES PREFIX "")
  set_target_properties(pyds PROPERTIES OUTPUT_NAME "pyds")
  
@@ -131,7 +131,7 @@ index 043324d..a081111 100644
 -add_custom_target(pip_wheel ALL DEPENDS ${PIP_WHEEL})
 +target_link_libraries(pyds nvbufsurface nvbufsurftransform)
 diff --git a/bindings/include/pyds.hpp b/bindings/include/pyds.hpp
-index 971b0b4..f0c656f 100644
+index 252b961..6b16668 100644
 --- a/bindings/include/pyds.hpp
 +++ b/bindings/include/pyds.hpp
 @@ -19,7 +19,7 @@
@@ -143,13 +143,6 @@ index 971b0b4..f0c656f 100644
  #include "pybind11/pybind11.h"
  #include "pybind11/cast.h"
  #include "pybind11/pytypes.h"
-@@ -52,4 +52,4 @@ namespace pydeepstream {
-     // rewritting ""_a operator from pybind11 namespace and putting it into
-     // pydeepstream namespace
-     py::arg operator ""_a(const char *str, size_t len);
--}
-\ No newline at end of file
-+}
 diff --git a/bindings/include/utils.hpp b/bindings/include/utils.hpp
 index f713b9b..49d6cca 100644
 --- a/bindings/include/utils.hpp

--- a/recipes-devtools/deepstream/deepstream-6.3-pyds/0002-Allow-apps-to-be-run-from-other-working-directories.patch
+++ b/recipes-devtools/deepstream/deepstream-6.3-pyds/0002-Allow-apps-to-be-run-from-other-working-directories.patch
@@ -1,28 +1,28 @@
-From e3bd9dfeb3384fa1024d91896d000832fe0e6af2 Mon Sep 17 00:00:00 2001
+From 426becc45c68a56f58770a64119289823b249b6b Mon Sep 17 00:00:00 2001
 From: Ilies CHERGUI <ilies.chergui@gmail.com>
-Date: Sun, 5 Feb 2023 16:33:33 +0000
+Date: Sun, 13 Aug 2023 19:29:37 +0100
 Subject: [PATCH 2/2] Allow apps to be run from other working directories
 
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
- apps/common/is_aarch_64.py                       |  4 ----
- apps/common/utils.py                             |  2 --
- ...deepstream_imagedata-multistream_redaction.py |  8 ++++----
- .../deepstream_imagedata-multistream.py          |  7 ++++---
- .../deepstream_nvdsanalytics.py                  | 11 ++++++-----
- .../deepstream-opticalflow.py                    |  3 ++-
- .../deepstream_test1_rtsp_in_rtsp_out.py         |  9 +++++----
- .../deepstream_segmentation.py                   |  6 +++---
- .../deepstream_ssd_parser.py                     | 11 ++++++-----
- .../deepstream_test1_rtsp_out.py                 |  7 ++++---
- .../deepstream_test_1_usb.py                     |  7 ++++---
- apps/deepstream-test1/deepstream_test_1.py       |  7 ++++---
- apps/deepstream-test2/deepstream_test_2.py       | 16 +++++++++-------
- apps/deepstream-test3/deepstream_test_3.py       |  7 ++++---
- apps/deepstream-test4/deepstream_test_4.py       | 10 +++++-----
- .../deepstream_rt_src_add_del.py                 | 15 ++++++++-------
- 16 files changed, 68 insertions(+), 62 deletions(-)
+ apps/common/is_aarch_64.py                        |  4 ----
+ apps/common/utils.py                              |  2 --
+ .../deepstream_imagedata-multistream_redaction.py |  8 ++++----
+ .../deepstream_imagedata-multistream.py           |  8 ++++----
+ .../deepstream_nvdsanalytics.py                   | 11 ++++++-----
+ .../deepstream-opticalflow.py                     |  3 ++-
+ .../deepstream_test1_rtsp_in_rtsp_out.py          |  9 +++++----
+ .../deepstream_segmentation.py                    |  6 +++---
+ .../deepstream_ssd_parser.py                      | 11 ++++++-----
+ .../deepstream_test1_rtsp_out.py                  |  7 ++++---
+ .../deepstream_test_1_usb.py                      |  7 ++++---
+ apps/deepstream-test1/deepstream_test_1.py        |  7 ++++---
+ apps/deepstream-test2/deepstream_test_2.py        | 15 ++++++++-------
+ apps/deepstream-test3/deepstream_test_3.py        |  7 ++++---
+ apps/deepstream-test4/deepstream_test_4.py        | 10 +++++-----
+ .../deepstream_rt_src_add_del.py                  | 15 ++++++++-------
+ 16 files changed, 67 insertions(+), 63 deletions(-)
 
 diff --git a/apps/common/is_aarch_64.py b/apps/common/is_aarch_64.py
 index 26276c3..b287613 100644
@@ -79,13 +79,14 @@ index c4397d6..aaa15d1 100644
      if (pgie_batch_size != number_sources):
          print("WARNING: Overriding infer-config batch-size", pgie_batch_size, " with number of sources ",
 diff --git a/apps/deepstream-imagedata-multistream/deepstream_imagedata-multistream.py b/apps/deepstream-imagedata-multistream/deepstream_imagedata-multistream.py
-index b1a2e93..957ab7d 100755
+index b1a2e93..4a3ff65 100755
 --- a/apps/deepstream-imagedata-multistream/deepstream_imagedata-multistream.py
 +++ b/apps/deepstream-imagedata-multistream/deepstream_imagedata-multistream.py
-@@ -18,8 +18,9 @@
+@@ -17,9 +17,9 @@
+ # limitations under the License.
  ################################################################################
  
- import sys
+-import sys
 -
 -sys.path.append('../')
 +import sys, os
@@ -94,7 +95,7 @@ index b1a2e93..957ab7d 100755
  import gi
  import configparser
  
-@@ -362,7 +363,7 @@ def main(args):
+@@ -362,7 +362,7 @@ def main(args):
      streammux.set_property('height', 1080)
      streammux.set_property('batch-size', number_sources)
      streammux.set_property('batched-push-timeout', 4000000)
@@ -104,7 +105,7 @@ index b1a2e93..957ab7d 100755
      if (pgie_batch_size != number_sources):
          print("WARNING: Overriding infer-config batch-size", pgie_batch_size, " with number of sources ",
 diff --git a/apps/deepstream-nvdsanalytics/deepstream_nvdsanalytics.py b/apps/deepstream-nvdsanalytics/deepstream_nvdsanalytics.py
-index 9bafdd5..aea65d4 100755
+index 208ddf3..1a493b4 100755
 --- a/apps/deepstream-nvdsanalytics/deepstream_nvdsanalytics.py
 +++ b/apps/deepstream-nvdsanalytics/deepstream_nvdsanalytics.py
 @@ -17,8 +17,9 @@
@@ -147,7 +148,7 @@ index 9bafdd5..aea65d4 100755
  
      for key in config['tracker']:
 diff --git a/apps/deepstream-opticalflow/deepstream-opticalflow.py b/apps/deepstream-opticalflow/deepstream-opticalflow.py
-index 750a592..1f4fa63 100755
+index 1a67dbf..ccbb9c5 100755
 --- a/apps/deepstream-opticalflow/deepstream-opticalflow.py
 +++ b/apps/deepstream-opticalflow/deepstream-opticalflow.py
 @@ -22,7 +22,8 @@ import os
@@ -161,7 +162,7 @@ index 750a592..1f4fa63 100755
  import numpy as np
  
 diff --git a/apps/deepstream-rtsp-in-rtsp-out/deepstream_test1_rtsp_in_rtsp_out.py b/apps/deepstream-rtsp-in-rtsp-out/deepstream_test1_rtsp_in_rtsp_out.py
-index 88fd89b..645cfff 100755
+index d8af91a..ca58f51 100755
 --- a/apps/deepstream-rtsp-in-rtsp-out/deepstream_test1_rtsp_in_rtsp_out.py
 +++ b/apps/deepstream-rtsp-in-rtsp-out/deepstream_test1_rtsp_in_rtsp_out.py
 @@ -16,8 +16,9 @@
@@ -176,8 +177,8 @@ index 88fd89b..645cfff 100755
  from common.bus_call import bus_call
  from common.is_aarch_64 import is_aarch64
  import pyds
-@@ -302,9 +303,9 @@ def main(args):
-     streammux.set_property("batched-push-timeout", 4000000)
+@@ -287,9 +288,9 @@ def main(args):
+         streammux.set_property("attach-sys-ts", 0)
  
      if gie=="nvinfer":
 -        pgie.set_property("config-file-path", "dstest1_pgie_config.txt")
@@ -325,7 +326,7 @@ index a03d326..d765c57 100755
      print("Adding elements to Pipeline \n")
      pipeline.add(source)
 diff --git a/apps/deepstream-test2/deepstream_test_2.py b/apps/deepstream-test2/deepstream_test_2.py
-index bcafbe2..44f60c1 100755
+index 2968db0..7c74c37 100755
 --- a/apps/deepstream-test2/deepstream_test_2.py
 +++ b/apps/deepstream-test2/deepstream_test_2.py
 @@ -17,8 +17,9 @@
@@ -340,7 +341,7 @@ index bcafbe2..44f60c1 100755
  import platform
  import configparser
  
-@@ -257,14 +258,15 @@ def main(args):
+@@ -254,14 +255,14 @@ def main(args):
      streammux.set_property('batched-push-timeout', 4000000)
  
      #Set properties of pgie and sgie
@@ -352,7 +353,6 @@ index bcafbe2..44f60c1 100755
 +    sgie1.set_property('config-file-path', os.path.join(HERE, "dstest2_sgie1_config.txt"))
 +    sgie2.set_property('config-file-path', os.path.join(HERE, "dstest2_sgie2_config.txt"))
 +    sgie3.set_property('config-file-path', os.path.join(HERE, "dstest2_sgie3_config.txt"))
-+
  
      #Set properties of tracker
      config = configparser.ConfigParser()
@@ -415,7 +415,7 @@ index b22cc64..be33348 100755
  pgie_classes_str = ["Vehicle", "TwoWheeler", "Person", "Roadsign"]
  
 diff --git a/apps/runtime_source_add_delete/deepstream_rt_src_add_del.py b/apps/runtime_source_add_delete/deepstream_rt_src_add_del.py
-index 991bd9a..4eee5bb 100644
+index 1ed7988..2253264 100644
 --- a/apps/runtime_source_add_delete/deepstream_rt_src_add_del.py
 +++ b/apps/runtime_source_add_delete/deepstream_rt_src_add_del.py
 @@ -17,8 +17,9 @@

--- a/recipes-devtools/deepstream/deepstream-6.3-pyds_1.1.8.bb
+++ b/recipes-devtools/deepstream/deepstream-6.3-pyds_1.1.8.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "Python bindings for Deepstream-6.2"
+DESCRIPTION = "Python bindings for Deepstream-6.3"
 HOMEPAGE = "https://github.com/NVIDIA-AI-IOT/deepstream_python_apps"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7a01a47514ea2d404b8db41b6cfe6db0"
@@ -9,8 +9,8 @@ SRC_URI = "git://${SRC_REPO};branch=${SRCBRANCH} \
            file://0001-Fixes-for-cross-building.patch \
            file://0002-Allow-apps-to-be-run-from-other-working-directories.patch \
            "
-# v1.1.6 tag
-SRCREV = "441b50da01779a2afacc60d40cd666d4bdde628e"
+# v1.1.8 tag
+SRCREV = "8178b5e611ccdc23bef39caf2f1f07b14d39a7cb"
 
 #PV .= "+git${SRCPV}"
 
@@ -18,8 +18,8 @@ COMPATIBLE_MACHINE = "(tegra)"
 
 S = "${WORKDIR}/git"
 
-DEPENDS = "deepstream-6.2 python3-pybind11 gstreamer1.0-python gstreamer1.0 glib-2.0"
-DS_PATH = "/opt/nvidia/deepstream/deepstream-6.2"
+DEPENDS = "deepstream-6.3 python3-pybind11 gstreamer1.0-python gstreamer1.0 glib-2.0"
+DS_PATH = "/opt/nvidia/deepstream/deepstream-6.3"
 
 inherit setuptools3 cmake pkgconfig ptest
 
@@ -50,5 +50,5 @@ do_install() {
 PACKAGES += "${PN}-samples"
 RDEPENDS:${PN} = "python3-pygobject gstreamer1.0-python"
 FILES:${PN}-samples = "${DS_PATH}/sources/deepstream_python_apps"
-RDEPENDS:${PN}-samples = "${PN} deepstream-6.2-samples-data python3-opencv python3-numpy gobject-introspection"
+RDEPENDS:${PN}-samples = "${PN} deepstream-6.3-samples-data python3-opencv python3-numpy gobject-introspection"
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"

--- a/recipes-devtools/deepstream/deepstream-6.3_6.3.0-1.bb
+++ b/recipes-devtools/deepstream/deepstream-6.3_6.3.0-1.bb
@@ -2,16 +2,16 @@ DESCRIPTION = "NVIDIA Deepstream SDK"
 HOMEPAGE = "https://developer.nvidia.com/deepstream-sdk"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = " \
-    file://usr/share/doc/deepstream-6.2/copyright;md5=6d940d04ee16883d3cb354fcf72498b2 \
-    file://opt/nvidia/deepstream/deepstream-6.2/LICENSE.txt;md5=2c2c89b896d6ff98d77ceec8d1a56082 \
-    file://opt/nvidia/deepstream/deepstream-6.2/doc/nvidia-tegra/LICENSE.iothub_client;md5=4f8c6347a759d246b5f96281726b8611 \
-    file://opt/nvidia/deepstream/deepstream-6.2/doc/nvidia-tegra/LICENSE.nvds_amqp_protocol_adaptor;md5=8b4b651fa4090272b2e08e208140a658 \
+    file://usr/share/doc/deepstream-6.3/copyright;md5=165df2c88b1df616c8599ed83276c92b \
+    file://opt/nvidia/deepstream/deepstream-6.3/LICENSE.txt;md5=8defc274ed63a1a47ea251872da763ce \
+    file://opt/nvidia/deepstream/deepstream-6.3/doc/nvidia-tegra/LICENSE.iothub_client;md5=4f8c6347a759d246b5f96281726b8611 \
+    file://opt/nvidia/deepstream/deepstream-6.3/doc/nvidia-tegra/LICENSE.nvds_amqp_protocol_adaptor;md5=8b4b651fa4090272b2e08e208140a658 \
 "
 
 inherit l4t_deb_pkgfeed
 
 SRC_COMMON_DEBS = "${BPN}_${PV}_arm64.deb;subdir=${BPN}"
-SRC_URI[sha256sum] = "0029fb3b4cad214e24844d9532703ef7809c097df9d92b0567dd8963e3a9dbd2"
+SRC_URI[sha256sum] = "f3961bc473312d46f5e2568f41b37913cb09a5aef69d905451eaea9cb5ad42cf"
 
 COMPATIBLE_MACHINE = "(tegra)"
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"
@@ -29,7 +29,8 @@ PACKAGECONFIG[realsense] = ""
 
 DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-rtsp-server \
     tensorrt-core tensorrt-plugins libnvvpi2 libcufft libcublas libnpp json-glib \
-    openssl111 tegra-libraries-multimedia-ds tegra-libraries-multimedia yaml-cpp-060 mdns grpc protobuf \
+    openssl111 tegra-libraries-multimedia-ds tegra-libraries-multimedia yaml-cpp-060 mdns \
+    grpc protobuf tegra-libraries-nvdsseimeta libgstnvcustomhelper mosquitto jsoncpp \
 "
 # XXX--- see hack in do_install
 DEPENDS += "patchelf-native"
@@ -39,7 +40,7 @@ S = "${WORKDIR}/${BPN}"
 B = "${WORKDIR}/build"
 
 DEEPSTREAM_BASEDIR = "/opt/nvidia/deepstream"
-DEEPSTREAM_PATH = "${DEEPSTREAM_BASEDIR}/deepstream-6.2"
+DEEPSTREAM_PATH = "${DEEPSTREAM_BASEDIR}/deepstream-6.3"
 SYSROOT_DIRS += "${DEEPSTREAM_PATH}/lib/"
 
 do_configure() {
@@ -61,6 +62,8 @@ do_configure() {
             fi
         fi
     done
+    rm -rf ${S}${DEEPSTREAM_PATH}/sources/libs/gstnvcustomhelper
+    rm -f ${S}${DEEPSTREAM_PATH}/sources/includes/gst-nvcustomevent.h
 }
 
 do_install() {
@@ -95,7 +98,6 @@ do_install() {
     # Some of the libraries are not using the right SONAME
     # in its DT_NEEDED ELF header, so we have to rewrite it to prevent
     # a broken runtime dependency.
-    patchelf --replace-needed libdns_sd.so.1.0.0 libdns_sd.so.1 ${D}${DEEPSTREAM_PATH}/lib/libnvds_nvmultiobjecttracker.so
     patchelf --replace-needed libdns_sd.so.1.0.0 libdns_sd.so.1 ${D}${DEEPSTREAM_PATH}/lib/libnvds_nmos.so
     patchelf --replace-needed libcufft.so libcufft.so.10 ${D}${DEEPSTREAM_PATH}/lib/libnvds_nvmultiobjecttracker.so
     patchelf --replace-needed libcublas.so libcublas.so.11 ${D}${DEEPSTREAM_PATH}/lib/libnvds_nvmultiobjecttracker.so
@@ -107,9 +109,10 @@ do_install() {
     patchelf --replace-needed libprotobuf.so.3.15.8.0 libprotobuf.so.32 ${D}${DEEPSTREAM_PATH}/lib/libnvds_riva_audio_proto.so
     patchelf --replace-needed libnppial.so libnppial.so.11 ${D}${DEEPSTREAM_PATH}/lib/libnvds_vpicanmatch.so
     patchelf --replace-needed libnppist.so libnppist.so.11 ${D}${DEEPSTREAM_PATH}/lib/libnvds_vpicanmatch.so
+    patchelf --replace-needed libjsoncpp.so.1 libjsoncpp.so.25 ${D}${DEEPSTREAM_PATH}/lib/libnvds_rest_server.so
     # ---XXX
     cd ${D}${DEEPSTREAM_BASEDIR}
-    ln -s deepstream-6.2 deepstream
+    ln -s deepstream-6.3 deepstream
     cd -
 }
 
@@ -158,8 +161,10 @@ FILES:${PN}-kafka = "${DEEPSTREAM_PATH}/lib/libnvds_kafka*"
 FILES:${PN}-redis = "${DEEPSTREAM_PATH}/lib/libnvds_redis*"
 FILES:${PN}-rivermax = "${libdir}/gstreamer-1.0/deepstream/libnvdsgst_udp.so"
 FILES:${PN}-realsense = "${DEEPSTREAM_PATH}/lib/libnvds_3d_dataloader_realsense.so"
+FILES:${PN}-staticdev = "${libdir}/gstreamer-1.0/deepstream/libnvdsgst_multistream_legacy.a"
 
-RDEPENDS:${PN}-samples = "${PN}-samples-data"
+RDEPENDS:${PN} = "libgstnvcustomhelper"
+RDEPENDS:${PN}-samples = "${PN}-samples-data libgstnvcustomhelper"
 RDEPENDS:${PN}-samples-data = "bash"
 RDEPENDS:${PN}-sources = "bash ${PN}-samples-data ${PN}"
 RRECOMMENDS:${PN} = "liberation-fonts"

--- a/recipes-test/tegra-tests/deepstream-tests/run-deepstream-tests.sh
+++ b/recipes-test/tegra-tests/deepstream-tests/run-deepstream-tests.sh
@@ -8,7 +8,7 @@
 # Some of these tests work better if you use jetson_clocks to
 # speed things up.
 
-DEEPSTREAM_PATH="/opt/nvidia/deepstream/deepstream-6.2"
+DEEPSTREAM_PATH="/opt/nvidia/deepstream/deepstream-6.3"
 SAMPLEROOT="${DEEPSTREAM_PATH}/sources/apps/sample_apps"
 PYSAMPLEROOT="${DEEPSTREAM_PATH}/sources/deepstream_python_apps/apps"
 STREAMS="${DEEPSTREAM_PATH}/samples/streams"

--- a/recipes-test/tegra-tests/deepstream-tests_1.0.bb
+++ b/recipes-test/tegra-tests/deepstream-tests_1.0.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "Scripts for testing Tegra DeepStream 6.1 samples"
+DESCRIPTION = "Scripts for testing Tegra DeepStream 6.3 samples"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
@@ -17,9 +17,9 @@ do_install() {
 
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"
 RDEPENDS:${PN} = " \
-    deepstream-6.2 \
-    deepstream-6.2-samples \
-    deepstream-6.2-pyds \
-    deepstream-6.2-pyds-samples \
+    deepstream-6.3 \
+    deepstream-6.3-samples \
+    deepstream-6.3-pyds \
+    deepstream-6.3-pyds-samples \
     tegra-tools-jetson-clocks \
 "


### PR DESCRIPTION
* Tests were done by using `demo-image-full` image on `Jetson AGX Orin` devkit
*  add the following line into your `conf/local.conf`
```
CORE_IMAGE_BASE_INSTALL:append = " deepstream-tests deepstream-6.3 deepstream-6.3-pyds"
```
* Run `run-deepstream-tests` script

```
nvstreammux: Successfully handled EOS for source_id=0
Frame Number= 1438 Number of Objects= 16 Vehicle_count= 13 Person_count= 3
Frame Number= 1438 Number of Objects= 15 Vehicle_count= 12 Person_count= 3
Frame Number= 1439 Number of Objects= 14 Vehicle_count= 11 Person_count= 3
Frame Number= 1439 Number of Objects= 14 Vehicle_count= 11 Person_count= 3
Frame Number= 1440 Number of Objects= 13 Vehicle_count= 11 Person_count= 2
Frame Number= 1440 Number of Objects= 15 Vehicle_count= 12 Person_count= 3
nvstreammux: Successfully handled EOS for source_id=1
Frame Number= 1441 Number of Objects= 15 Vehicle_count= 12 Person_count= 3
Frame Number= 1441 Number of Objects= 0 Vehicle_count= 0 Person_count= 0
Frame Number= 1442 Number of Objects= 0 Vehicle_count= 0 Person_count= 0
End-of-stream
Exiting app

=== PASS:  py_deepstream_test3 ===
Tests run:     6
Tests passed:  6
Tests skipped: 0
Tests failed:  0
sh-5.2# 
```