### PR TITLE
nvidia-docker-tests: update remap for version 35.x

### DIFF
--- a/recipes-test/tegra-tests/nvidia-docker-tests/l4t_version_remap.sh.in
+++ b/recipes-test/tegra-tests/nvidia-docker-tests/l4t_version_remap.sh.in
@@ -21,6 +21,7 @@ check_remap() {
     #       https://catalog.ngc.nvidia.com/orgs/nvidia/containers/l4t-pytorch
     l4t_version_remap["32.7.2"]="32.7.1"
     l4t_version_remap["32.7.3"]="32.7.1"
+    l4t_version_remap["35.4.1"]="35.2.1"
 
     if [ "${l4t_version_remap[${L4T_VERSION}]+test}" ]; then
             L4T_VERSION_ACTUAL=${L4T_VERSION}


### PR DESCRIPTION
I've noticed the repo at https://github.com/dusty-nv/jetson-containers has undergone a major overhaul recently.  We'll need to pull in some [python dependencies](https://github.com/dusty-nv/jetson-containers/blob/master/requirements.txt) and possibly other things to use it.  Haven't tried to take that on at the moment, will patch the work off the legacy branch for now instead.