### PR TITLE
deepstream: fix header file collisions

### DIFF
--- a/recipes-devtools/deepstream/deepstream-6.3-pyds/0001-Fixes-for-cross-building.patch
+++ b/recipes-devtools/deepstream/deepstream-6.3-pyds/0001-Fixes-for-cross-building.patch
@@ -1,18 +1,19 @@
-From 0853effb1b2ead74c2413e4b282233cd0f7b51f5 Mon Sep 17 00:00:00 2001
+From f9a37f85ca1d259458a9116cad39280f5ae833e8 Mon Sep 17 00:00:00 2001
 From: Ilies CHERGUI <ilies.chergui@gmail.com>
 Date: Sun, 13 Aug 2023 19:07:16 +0100
-Subject: [PATCH 1/2] Fixes for cross-building
+Subject: [PATCH] Fixes for cross-building
 
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
- bindings/CMakeLists.txt    | 66 ++++++++++++--------------------------
+ bindings/CMakeLists.txt    | 69 ++++++++++++--------------------------
  bindings/include/pyds.hpp  |  2 +-
  bindings/include/utils.hpp |  2 +-
- 3 files changed, 22 insertions(+), 48 deletions(-)
+ 3 files changed, 23 insertions(+), 50 deletions(-)
 
 diff --git a/bindings/CMakeLists.txt b/bindings/CMakeLists.txt
-index d89d5e8..a482f25 100644
+index d89d5e8..7426793 100644
 --- a/bindings/CMakeLists.txt
 +++ b/bindings/CMakeLists.txt
 @@ -13,7 +13,8 @@
@@ -41,7 +42,7 @@ index d89d5e8..a482f25 100644
  
  
  # Checking values are allowed
-@@ -36,23 +38,20 @@ macro(check_variable_allowed var_name var_list)
+@@ -36,37 +38,27 @@ macro(check_variable_allowed var_name var_list)
  endmacro()
  set(PYTHON_MAJVERS_ALLOWED 3)
  check_variable_allowed(PYTHON_MAJOR_VERSION PYTHON_MAJVERS_ALLOWED)
@@ -67,11 +68,12 @@ index d89d5e8..a482f25 100644
  
  # Describing pyds build
 -project(pyds DESCRIPTION "Python bindings for Deepstream")
- add_compile_options(-Wall -Wextra -pedantic -O3)
+-add_compile_options(-Wall -Wextra -pedantic -O3)
++add_compile_options(-Wall -Wextra -pedantic -O3 -I=${DS_PATH}/sources/includes/)
  
  include_directories(
-@@ -60,13 +59,7 @@ include_directories(
-         ${DS_PATH}/sources/includes/
+         include/
+-        ${DS_PATH}/sources/includes/
          include/bind
          include/nvds
 -        ../3rdparty/pybind11/include/pybind11/
@@ -85,7 +87,7 @@ index d89d5e8..a482f25 100644
          )
  
  add_library(pyds SHARED src/pyds.cpp src/utils.cpp src/bindanalyticsmeta.cpp
-@@ -78,37 +71,18 @@ add_library(pyds SHARED src/pyds.cpp src/utils.cpp src/bindanalyticsmeta.cpp
+@@ -78,37 +70,18 @@ add_library(pyds SHARED src/pyds.cpp src/utils.cpp src/bindanalyticsmeta.cpp
  set_target_properties(pyds PROPERTIES PREFIX "")
  set_target_properties(pyds PROPERTIES OUTPUT_NAME "pyds")
  
@@ -156,6 +158,3 @@ index f713b9b..49d6cca 100644
  
  namespace py = pybind11;
  
--- 
-2.25.1
-

--- a/recipes-devtools/deepstream/deepstream-6.3_6.3.0-1.bb
+++ b/recipes-devtools/deepstream/deepstream-6.3_6.3.0-1.bb
@@ -41,7 +41,7 @@ B = "${WORKDIR}/build"
 
 DEEPSTREAM_BASEDIR = "/opt/nvidia/deepstream"
 DEEPSTREAM_PATH = "${DEEPSTREAM_BASEDIR}/deepstream-6.3"
-SYSROOT_DIRS += "${DEEPSTREAM_PATH}/lib/"
+SYSROOT_DIRS += "${DEEPSTREAM_PATH}/lib/ ${DEEPSTREAM_PATH}/sources/includes/"
 
 do_configure() {
     for feature in azure amqp kafka redis triton rivermax realsense; do
@@ -88,10 +88,6 @@ do_install() {
     install -m 0644 ${S}${DEEPSTREAM_PATH}/lib/gst-plugins/* ${D}${libdir}/gstreamer-1.0/deepstream/
 
     cp -R --preserve=mode,timestamps ${S}${DEEPSTREAM_PATH}/samples ${D}${DEEPSTREAM_PATH}/
-
-    install -d ${D}${includedir}/deepstream
-    cp -R --preserve=mode,timestamps ${S}${DEEPSTREAM_PATH}/sources/includes/* ${D}${includedir}/
-
     cp -R --preserve=mode,timestamps ${S}${DEEPSTREAM_PATH}/sources/ ${D}${DEEPSTREAM_PATH}/
 
     # XXX---
@@ -128,7 +124,7 @@ def pkgconf_packages(d):
 
 PKGCONF_PACKAGES = "${@pkgconf_packages(d)}"
 
-PACKAGES =+ "${PN}-samples-data ${PN}-samples ${PN}-sources ${PKGCONF_PACKAGES}"
+PACKAGES = "${PN}-samples-data ${PN}-samples ${PN}-dev ${PN}-sources ${PN}-dbg ${PKGCONF_PACKAGES} ${PACKAGE_BEFORE_PN} ${PN}"
 
 FILES:${PN} = "\
     ${sysconfdir}/ld.so.conf.d/  \
@@ -137,7 +133,7 @@ FILES:${PN} = "\
     ${DEEPSTREAM_BASEDIR} \
 "
 
-FILES:${PN}-dev = "${includedir}"
+FILES:${PN}-dev = "${DEEPSTREAM_PATH}/sources/includes"
 
 FILES:${PN}-samples = "${bindir}/*"
 FILES:${PN}-samples-data = "\
@@ -167,4 +163,5 @@ RDEPENDS:${PN} = "libgstnvcustomhelper"
 RDEPENDS:${PN}-samples = "${PN}-samples-data libgstnvcustomhelper"
 RDEPENDS:${PN}-samples-data = "bash"
 RDEPENDS:${PN}-sources = "bash ${PN}-samples-data ${PN}"
+RRECOMMENDS:${PN}-sources += "${PN}-dev"
 RRECOMMENDS:${PN} = "liberation-fonts"


### PR DESCRIPTION
* Leave the deepstream headers under `/opt/deepstream`, rather than double-installing them into `${includedir}`
* Update the deepstream-pyds recipe to find the headers in the correct deepstream-specific location

Fixes [meta-tegra #1401](https://github.com/OE4T/meta-tegra/issues/1401)