### PR TITLE
re2: set branch to main

### DIFF
--- a/recipes-support/re2/re2_2020.11.01.bb
+++ b/recipes-support/re2/re2_2020.11.01.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b5c31eb512bdf3cb11ffd5713963760"
 
 SRCREV = "166dbbeb3b0ab7e733b278e8f42a84f6882b8a25"
 
-SRC_URI = "git://github.com/google/re2.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/google/re2.git;branch=main;protocol=https"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
RE2 renamed the master branch in main.

This is only relevant for `Dunfell` since RE2 is part of `meta-oe` since `Kirkstone`.