### PR TITLE
Update TensorRT test script

### DIFF
--- a/recipes-test/tegra-tests/tensorrt-tests/run-tensorrt-tests.sh
+++ b/recipes-test/tegra-tests/tensorrt-tests/run-tensorrt-tests.sh
@@ -75,12 +75,11 @@ run_trtexec(){
         echo "Skipping trtexec"
         return $SKIPCODE
     fi
-    copy_mnist_data
-    echo "Running trtexec: A Simple mnist model from Caffe"
-    trtexec --deploy=${SAMPLEDATA}/mnist/mnist.prototxt \
-      --model=${SAMPLEDATA}/mnist/mnist.caffemodel --output=prob \
-      --batch=16 --saveEngine=mnist16.trt && \
-	trtexec --loadEngine=mnist16.trt --batch=16
+    copy_resnet50_data
+    echo "Running trtexec: Running an ONNX model with full dimensions"
+    trtexec --onnx=${SAMPLEDATA}/resnet50/ResNet50.onnx \
+      --saveEngine=ResNet50.trt && \
+	trtexec --loadEngine=ResNet50.trt --batch=1
 }
 
 TESTS="algorithm_selector char-rnn dynamic_reshape"


### PR DESCRIPTION
mnist.prototxt were removed in JetPack 6.0 / L4T R36.2.0 DP

* Tests were done on machine `jetson-agx-orin-devkit` with `demo-image-full` image.

```
[02/27/2024-18:35:51] [I] Average on 10 runs - GPU latency: 4.78064 ms - Host latency: 4.83948 ms (enqueue 0.356567 ms)
[02/27/2024-18:35:51] [I] Average on 10 runs - GPU latency: 4.77766 ms - Host latency: 4.83599 ms (enqueue 0.356763 ms)
[02/27/2024-18:35:51] [I] Average on 10 runs - GPU latency: 4.7771 ms - Host latency: 4.83513 ms (enqueue 0.363037 ms)
[02/27/2024-18:35:51] [I] Average on 10 runs - GPU latency: 4.77773 ms - Host latency: 4.8364 ms (enqueue 0.363794 ms)
[02/27/2024-18:35:51] [I] 
[02/27/2024-18:35:51] [I] === Performance summary ===
[02/27/2024-18:35:51] [I] Throughput: 208.729 qps
[02/27/2024-18:35:51] [I] Latency: min = 4.81763 ms, max = 4.86572 ms, mean = 4.83767 ms, median = 4.83752 ms, percentile(90%) = 4.84772 ms, percentile(95%) = 4.85034 ms, percentile(99%) = 4.85547 ms
[02/27/2024-18:35:51] [I] Enqueue Time: min = 0.345459 ms, max = 0.39978 ms, mean = 0.357979 ms, median = 0.356689 ms, percentile(90%) = 0.365295 ms, percentile(95%) = 0.372803 ms, percentile(99%) = 0.384033 ms
[02/27/2024-18:35:51] [I] H2D Latency: min = 0.0480957 ms, max = 0.0679321 ms, mean = 0.0507424 ms, median = 0.050293 ms, percentile(90%) = 0.052002 ms, percentile(95%) = 0.0533447 ms, percentile(99%) = 0.0574951 ms
[02/27/2024-18:35:51] [I] GPU Compute Time: min = 4.76001 ms, max = 4.80023 ms, mean = 4.77896 ms, median = 4.77863 ms, percentile(90%) = 4.7887 ms, percentile(95%) = 4.79102 ms, percentile(99%) = 4.79639 ms
[02/27/2024-18:35:51] [I] D2H Latency: min = 0.00537109 ms, max = 0.0102539 ms, mean = 0.00796696 ms, median = 0.00799561 ms, percentile(90%) = 0.0088501 ms, percentile(95%) = 0.00927734 ms, percentile(99%) = 0.00964355 ms
[02/27/2024-18:35:51] [I] Total Host Walltime: 3.01347 s
[02/27/2024-18:35:51] [I] Total GPU Compute Time: 3.00596 s
[02/27/2024-18:35:51] [I] Explanations of the performance metrics are printed in the verbose logs.
[02/27/2024-18:35:51] [I] 
&&&& PASSED TensorRT.trtexec [TensorRT v8602] # trtexec --loadEngine=ResNet50.trt --batch=1
=== PASS:  trtexec ===
Tests run:     7
Tests passed:  7
Tests skipped: 0
Tests failed:  0
root@jetson-agx-orin-devkit:~#
```
 Fixes #110 


