### PR TITLE
deepstream-6.3: PACKAGECONFIG updates

### DIFF
--- a/recipes-devtools/deepstream/deepstream-6.3_6.3.0-1.bb
+++ b/recipes-devtools/deepstream/deepstream-6.3_6.3.0-1.bb
@@ -21,15 +21,19 @@ PACKAGECONFIG[amqp] = ",,rabbitmq-c"
 PACKAGECONFIG[kafka] = ",,librdkafka"
 # NB: requires hiredis 1.0.0+
 PACKAGECONFIG[redis] = ",,hiredis"
+# NB: requires avahi to be built with 'libdns_sd' in PACKAGECONFIG
+#     which is not the default
+PACKAGECONFIG[nmos] = ",,avahi"
+# NB: requires Azure IoT Hub client library Azure IoT SDK
+PACKAGECONFIG[azure] = ",,azure-iot-sdk"
 # NB: need recipes for these dependencies
-PACKAGECONFIG[azure] = ""
 PACKAGECONFIG[triton] = ""
 PACKAGECONFIG[rivermax] = ""
 PACKAGECONFIG[realsense] = ""
 
 DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-rtsp-server \
     tensorrt-core tensorrt-plugins libnvvpi2 libcufft libcublas libnpp json-glib \
-    openssl111 tegra-libraries-multimedia-ds tegra-libraries-multimedia yaml-cpp-060 mdns \
+    openssl111 tegra-libraries-multimedia-ds tegra-libraries-multimedia yaml-cpp-060 \
     grpc protobuf tegra-libraries-nvdsseimeta libgstnvcustomhelper mosquitto jsoncpp \
 "
 # XXX--- see hack in do_install
@@ -44,11 +48,17 @@ DEEPSTREAM_PATH = "${DEEPSTREAM_BASEDIR}/deepstream-6.3"
 SYSROOT_DIRS += "${DEEPSTREAM_PATH}/lib/ ${DEEPSTREAM_PATH}/sources/includes/"
 
 do_configure() {
-    for feature in azure amqp kafka redis triton rivermax realsense; do
+    for feature in azure amqp kafka nmos redis triton rivermax realsense; do
         if ! echo "${PACKAGECONFIG}" | grep -q "$feature"; then
             rm -f ${S}${DEEPSTREAM_PATH}/lib/libnvds_${feature}*
             if [ "$feature" = "azure" ]; then
-                rm -f ${S}${DEEPSTREAM_PATH}/lib/libiothub_client.so
+                rm -f ${D}${DEEPSTREAM_PATH}/lib/libnvds_azure*
+            fi
+            if [ "$feature" = "nmos" ]; then
+                rm -f ${S}${DEEPSTREAM_PATH}/lib/libnvds_nmos.so*
+                rm -f ${S}${DEEPSTREAM_PATH}/sources/includes/nvdsnmos.h
+                rm -f ${S}${DEEPSTREAM_PATH}/bin/deepstream-nmos-app
+                rm -rf ${S}${DEEPSTREAM_PATH}/apps/sample_apps/deepstream-nmos
             fi
             if [ "$feature" = "triton" ]; then
                 rm -f ${S}${DEEPSTREAM_PATH}/lib/gst-plugins/libnvdsgst_inferserver.so
@@ -64,6 +74,7 @@ do_configure() {
     done
     rm -rf ${S}${DEEPSTREAM_PATH}/sources/libs/gstnvcustomhelper
     rm -f ${S}${DEEPSTREAM_PATH}/sources/includes/gst-nvcustomevent.h
+    rm -f ${S}${DEEPSTREAM_PATH}/lib/libiothub_client.so*
 }
 
 do_install() {
@@ -96,7 +107,6 @@ do_install() {
     # a broken runtime dependency.
     grpc_soname=$(${OBJDUMP} -p ${STAGING_LIBDIR}/libgrpc.so | grep SONAME | awk '{print $2}')
     protobuf_soname=$(${OBJDUMP} -p ${STAGING_LIBDIR}/libprotobuf.so | grep SONAME | awk '{print $2}')
-    patchelf --replace-needed libdns_sd.so.1.0.0 libdns_sd.so.1 ${D}${DEEPSTREAM_PATH}/lib/libnvds_nmos.so
     patchelf --replace-needed libcufft.so libcufft.so.10 ${D}${DEEPSTREAM_PATH}/lib/libnvds_nvmultiobjecttracker.so
     patchelf --replace-needed libcublas.so libcublas.so.11 ${D}${DEEPSTREAM_PATH}/lib/libnvds_nvmultiobjecttracker.so
     patchelf --replace-needed libcufft.so libcufft.so.10 ${D}${DEEPSTREAM_PATH}/lib/libnvds_audiotransform.so
@@ -122,7 +132,7 @@ INHIBIT_SYSROOT_STRIP = "1"
 INSANE_SKIP = "dev-so ldflags"
 
 def pkgconf_packages(d):
-    pkgconf = bb.utils.filter('PACKAGECONFIG', 'azure amqp kafka redis triton rivermax realsense', d).split()
+    pkgconf = bb.utils.filter('PACKAGECONFIG', 'azure amqp kafka nmos redis triton rivermax realsense', d).split()
     pn = d.getVar('PN')
     return ' '.join(['{}-{}'.format(pn, p) for p in pkgconf])
 
@@ -151,7 +161,8 @@ FILES:${PN}-samples-data = "\
 
 FILES:${PN}-sources = "${DEEPSTREAM_PATH}/sources"
 
-FILES:${PN}-azure = "${DEEPSTREAM_PATH}/lib/libiothub_client.so ${DEEPSTREAM_PATH}/lib/libnvds_azure*"
+FILES:${PN}-azure = "${DEEPSTREAM_PATH}/lib/libnvds_azure*"
+FILES:${PN}-nmos = "${DEEPSTREAM_PATH}/lib/lib/libnvds_nmos*"
 FILES:${PN}-triton = "\
     ${libdir}/gstreamer-1.0/deepstream/libnvdsgst_inferserver.so \
     ${DEEPSTREAM_PATH}/lib/libnvds_infer_server.so \


### PR DESCRIPTION
* Added 'nmos' PACKAGECONFIG setting for enabling/disabling inclusion of NMOS (Network Media Open Specification) support, which requires avahi to be built with libdns_sd in its PACKAGECONFIG.
* Added dependency for the 'azure' PACKAGECONFIG setting on azure-iot-sdk

This is a backport of https://github.com/OE4T/meta-tegra-community/commit/79dea834cd0a04c7fd6399f8394905d759e707ce to deepstream 6.3

Resolves build error:
```
Running transaction check
Transaction check succeeded.
Running transaction test
Error: Transaction test error:
  file /usr/lib/libnss_mdns.so.2 conflicts between attempted installs of libnss-mdns-0.15.1-r0.armv8a_tegra and mdns-2200.100.94.0.2-r0.armv8a_tegra
```