### PR TITLE
python3-cuda: Add missing upstream status to patch

### DIFF
--- a/recipes-devtools/python/python3-cuda/0001-OE-cross-build-fixups.patch
+++ b/recipes-devtools/python/python3-cuda/0001-OE-cross-build-fixups.patch
@@ -3,6 +3,7 @@ From: Ilies CHERGUI <ichergui@nvidia.com>
 Date: Fri, 17 May 2024 18:59:13 +0100
 Subject: [PATCH] OE cross build fixups
 
+Upstream-Status: Inappropriate [OE-Specific]
 Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
 ---
  setup.py | 23 +++--------------------


### PR DESCRIPTION
OE-core/master has QA diagnostics about it and some distros e.g. yoe turn that into an Error

Fixes
ERROR: python3-cuda-12.2.1-r0 do_patch: QA Issue: Missing Upstream-Status in patch