### PR TITLE
nvidia-docker-tests: support r35.6.0

### DIFF
--- a/recipes-test/tegra-tests/nvidia-docker-tests/l4t_version_remap.sh.in
+++ b/recipes-test/tegra-tests/nvidia-docker-tests/l4t_version_remap.sh.in
@@ -22,6 +22,7 @@ check_remap() {
     l4t_version_remap["32.7.2"]="32.7.1"
     l4t_version_remap["32.7.3"]="32.7.1"
     l4t_version_remap["35.4.1"]="35.2.1"
+    l4t_version_remap["35.6.0"]="35.2.1"
 
     if [ "${l4t_version_remap[${L4T_VERSION}]+test}" ]; then
             L4T_VERSION_ACTUAL=${L4T_VERSION}


### PR DESCRIPTION
Add remap to the latest supported version of all containers to ensure run-docker-tests passes on r35.6.0