### PR TITLE
python3-pycuda: update to 2024.1

### DIFF
--- a/recipes-devtools/python/python3-pycuda_2024.1.bb
+++ b/recipes-devtools/python/python3-pycuda_2024.1.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8dd9e67c46dbe605fba6aeb236b48c8a"
 
 DEPENDS = "python3-setuptools-native python3-cython-native python3-cython python3-numpy-native cuda-profiler-api"
 
-SRC_URI[sha256sum] = "cd92e7246bb45ac3452955a110714112674cdf3b4a9e2f4ff25a4159c684e6bb"
+SRC_URI[sha256sum] = "d50d23ff6371482cff7d4b953ef40ab81c9df038ecb614484f9fd5347327327e"
 SRC_URI:append = " file://0001-add-nvcc-flag-allow-unsupported-compiler-to-allow-cu.patch"
 
 COMPATIBLE_MACHINE = "(tegra)"


### PR DESCRIPTION
I haven't tested this past the build step yet but wanted to get @ichergui's take on whether this was the right direction.

If we want to stick with 2022.2 on the r35.x branch I could figure out how to resolve the import module failure with a patch instead.

# Commit Message

Cherry pick of [1] and a backport for scarthgap-l4t-r35.x with the following change:
* Don't change the path used for cuda compile in 2022.2 since it references the correct version of CUDA (11.4) for the r35.x branch

Resolves
```
|   File "/home/dan/proj/build/tmp/work/armv8a_tegra234-poky-linux/python3-pycuda/2022.2.2/pycuda-2022.2.2/aksetup_helper.py", line 38, in get_numpy_incpath
|     from imp import find_module
| ModuleNotFoundError: No module named 'imp'
| ERROR: 'python3 setup.py bdist_wheel ' execution failed.
| WARNING: exit code 1 from a shell command.
```

1: https://github.com/OE4T/meta-tegra-community/commit/0d1282c7f34a516570122d5a3feaecf8635ae2fe