### PR TITLE
Fix CMake 4+ compatibility

### DIFF
--- a/recipes-devtools/cnmem/cnmem/0001-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
+++ b/recipes-devtools/cnmem/cnmem/0001-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
@@ -1,0 +1,40 @@
+From 4613616542c78090e1271153a44faf21cd927398 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Tue, 19 Aug 2025 13:13:01 +0100
+Subject: [PATCH] cmake: Set minimum required version to 3.5 for CMake 4+
+ compatibility
+
+Fix:
+
+| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
+|   Compatibility with CMake < 3.5 has been removed from CMake.
+|
+|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+|   to tell CMake that the project requires at least <min> but has been updated
+|   to work with policies introduced by <max> or earlier.
+|
+|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+|
+|
+| -- Configuring incomplete, errors occurred!
+
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cb9f4f1..78712aa 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # CMakeLists to build the cnmem library.
+-cmake_minimum_required(VERSION 2.8.8)
++cmake_minimum_required(VERSION 3.5)
+ project(cnmem)
+ 
+ # We need CUDA to build that library.
+-- 
+2.34.1
+

--- a/recipes-devtools/cnmem/cnmem_v1.0.0.bb
+++ b/recipes-devtools/cnmem/cnmem_v1.0.0.bb
@@ -2,7 +2,10 @@ DESCRIPTION = "A simple memory manager for CUDA designed to help Deep Learning f
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=927dd052e0c449ac0dd2c0b54d67626d"
 
-SRC_URI = "git://github.com/NVIDIA/cnmem.git;protocol=https;branch=master"
+SRC_URI = " \
+    git://github.com/NVIDIA/cnmem.git;protocol=https;branch=master \
+    file://0001-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch \
+"
 
 SRCREV = "c5573333feed2526d4301fca103c55cf3bcb9dcc"
 

--- a/recipes-devtools/dlpack/dlpack/0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
+++ b/recipes-devtools/dlpack/dlpack/0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
@@ -1,0 +1,42 @@
+From 7957c0c1a736be3ce76a486e07fee995039cda13 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Tue, 19 Aug 2025 14:34:51 +0100
+Subject: [PATCH 2/2] cmake: Set minimum required version to 3.5 for CMake 4+
+ compatibility
+
+Fix:
+
+| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
+|   Compatibility with CMake < 3.5 has been removed from CMake.
+|
+|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+|   to tell CMake that the project requires at least <min> but has been updated
+|   to work with policies introduced by <max> or earlier.
+|
+|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+|
+|
+| -- Configuring incomplete, errors occurred!
+
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ed9671a..cffe76b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,7 +2,7 @@
+ # Set minimum version of CMake. Since command 'project' use
+ # VERSION sub-option we need at least 3.0.
+ # Note: If you use 2.6 or 2.4, God kills a kitten. Seriously.
+-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+ 
+ ####
+ # Set variables:
+-- 
+2.34.1
+

--- a/recipes-devtools/dlpack/dlpack_1.0.bb
+++ b/recipes-devtools/dlpack/dlpack_1.0.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f62d4e85ba68a1574b74d97ab8dea9ab"
 SRC_URI = " \
     git://github.com/dmlc/dlpack.git;protocol=https;branch=main;tag=v${PV} \
     file://0001-update-dlpack-project-version.patch \
+    file://0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch \
 "
 SRCREV = "bbd2f4d32427e548797929af08cfe2a9cbb3cf12"
 

--- a/recipes-devtools/libevhtp/libevhtp/0001-fix-cmake-build.patch
+++ b/recipes-devtools/libevhtp/libevhtp/0001-fix-cmake-build.patch
@@ -1,14 +1,16 @@
-From 491ecafe3b3b8651fa51a3234170cabb394e15d8 Mon Sep 17 00:00:00 2001
-From: Roger Knecht <roger@norberthealth.com>
-Date: Wed, 22 Jun 2022 11:17:05 +0200
-Subject: [PATCH] fix cmake build
+From 7270f3bf9f42dbdda847c79b232697d6f09d548f Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Tue, 19 Aug 2025 16:12:20 +0100
+Subject: [PATCH 1/2] fix cmake build
 
 Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
 ---
- CMakeLists.txt        | 4 ++--
- cmake/Config.cmake.in | 3 +++
- 2 files changed, 5 insertions(+), 2 deletions(-)
+ CMakeLists.txt            |  4 ++--
+ cmake/Config.cmake.in     |  3 +++
+ cmake/TestBigEndian.cmake | 18 +++++++++---------
+ 3 files changed, 14 insertions(+), 11 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 481ddd0..dcf5685 100644
@@ -40,6 +42,58 @@ index b834857..20a2e07 100644
  set(package_deps @package_deps@)
  foreach(dep IN LISTS package_deps)
      find_package(${dep} REQUIRED)
+diff --git a/cmake/TestBigEndian.cmake b/cmake/TestBigEndian.cmake
+index fdc3adb..d9c7d31 100644
+--- a/cmake/TestBigEndian.cmake
++++ b/cmake/TestBigEndian.cmake
+@@ -56,25 +56,25 @@ macro(TEST_BIG_ENDIAN VARIABLE)
+     endif()
+ 
+ 
+-    configure_file("${CMAKE_ROOT}/Modules/TestEndianess.c.in"
+-                   "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/TestEndianess.c"
++    configure_file("${CMAKE_ROOT}/Modules/TestEndianness.c.in"
++                   "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/TestEndianness.c"
+                    @ONLY)
+ 
+-     file(READ "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/TestEndianess.c"
++     file(READ "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/TestEndianness.c"
+           TEST_ENDIANESS_FILE_CONTENT)
+ 
+      try_compile(HAVE_${VARIABLE}
+       "${CMAKE_BINARY_DIR}"
+-      "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/TestEndianess.c"
++      "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/TestEndianness.c"
+       OUTPUT_VARIABLE OUTPUT
+-      COPY_FILE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/TestEndianess.bin" )
++      COPY_FILE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/TestEndianness.bin" )
+ 
+       if(HAVE_${VARIABLE})
+ 
+-        file(STRINGS "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/TestEndianess.bin"
++        file(STRINGS "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/TestEndianness.bin"
+             CMAKE_TEST_ENDIANESS_STRINGS_LE LIMIT_COUNT 1 REGEX "THIS IS LITTLE ENDIAN")
+ 
+-        file(STRINGS "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/TestEndianess.bin"
++        file(STRINGS "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/TestEndianness.bin"
+             CMAKE_TEST_ENDIANESS_STRINGS_BE LIMIT_COUNT 1 REGEX "THIS IS BIG ENDIAN")
+ 
+         # on mac, if there are universal binaries built both will be true
+@@ -105,12 +105,12 @@ macro(TEST_BIG_ENDIAN VARIABLE)
+         endif()
+ 
+         file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+-          "Determining if the system is big endian passed with the following output:\n${OUTPUT}\nTestEndianess.c:\n${TEST_ENDIANESS_FILE_CONTENT}\n\n")
++          "Determining if the system is big endian passed with the following output:\n${OUTPUT}\nTestEndianness.c:\n${TEST_ENDIANESS_FILE_CONTENT}\n\n")
+ 
+       else()
+         message(STATUS "Check if the system is big endian - failed")
+         file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+-          "Determining if the system is big endian failed with the following output:\n${OUTPUT}\nTestEndianess.c:\n${TEST_ENDIANESS_FILE_CONTENT}\n\n")
++          "Determining if the system is big endian failed with the following output:\n${OUTPUT}\nTestEndianness.c:\n${TEST_ENDIANESS_FILE_CONTENT}\n\n")
+         set(${VARIABLE})
+       endif()
+   endif()
 -- 
-2.17.1
+2.34.1
 

--- a/recipes-devtools/libevhtp/libevhtp/0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
+++ b/recipes-devtools/libevhtp/libevhtp/0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
@@ -1,0 +1,39 @@
+From 92ff749866dc8e826021622f8b8dc59e2a54b3bd Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Tue, 19 Aug 2025 16:12:55 +0100
+Subject: [PATCH 2/2] cmake: Set minimum required version to 3.5 for CMake 4+
+ compatibility
+
+Fix:
+
+| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
+|   Compatibility with CMake < 3.5 has been removed from CMake.
+|
+|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+|   to tell CMake that the project requires at least <min> but has been updated
+|   to work with policies introduced by <max> or earlier.
+|
+|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+|
+|
+| -- Configuring incomplete, errors occurred!
+
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dcf5685..a404c2d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.5)
+ 
+ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+ 
+-- 
+2.34.1
+

--- a/recipes-devtools/libevhtp/libevhtp_1.2.18.bb
+++ b/recipes-devtools/libevhtp/libevhtp_1.2.18.bb
@@ -5,6 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=68e2a80f5f9020a66f4512962817cd66"
 SRC_URI = " \
     git://github.com/Yellow-Camper/libevhtp.git;protocol=https;branch=master \
     file://0001-fix-cmake-build.patch \
+    file://0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch \
 "
 
 SRCREV = "e200bfa85bf253e9cfe1c1a9e705fccb176b9171"

--- a/recipes-devtools/pytorch/pytorch/0007-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
+++ b/recipes-devtools/pytorch/pytorch/0007-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
@@ -1,0 +1,83 @@
+From 46e0bdcd591d25e13423d5e704388d33b5e5ede1 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Tue, 19 Aug 2025 15:23:12 +0100
+Subject: [PATCH 7/7] cmake: Set minimum required version to 3.5 for CMake 4+
+ compatibility
+
+Fix:
+
+| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
+|   Compatibility with CMake < 3.5 has been removed from CMake.
+|
+|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+|   to tell CMake that the project requires at least <min> but has been updated
+|   to work with policies introduced by <max> or earlier.
+|
+|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+|
+|
+| -- Configuring incomplete, errors occurred!
+
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ third_party/FP16/CMakeLists.txt                         | 2 +-
+ third_party/NNPACK/CMakeLists.txt                       | 2 +-
+ third_party/gloo/CMakeLists.txt                         | 2 +-
+ third_party/psimd/CMakeLists.txt                        | 2 +-
+ third_party/tensorpipe/third_party/libuv/CMakeLists.txt | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/third_party/FP16/CMakeLists.txt b/third_party/FP16/CMakeLists.txt
+index e0d87f86c..1fee16e14 100644
+--- a/third_party/FP16/CMakeLists.txt
++++ b/third_party/FP16/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5 FATAL_ERROR)
+ 
+ INCLUDE(GNUInstallDirs)
+ 
+diff --git a/third_party/NNPACK/CMakeLists.txt b/third_party/NNPACK/CMakeLists.txt
+index d808915a4..335073dba 100644
+--- a/third_party/NNPACK/CMakeLists.txt
++++ b/third_party/NNPACK/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5 FATAL_ERROR)
+ 
+ INCLUDE(GNUInstallDirs)
+ INCLUDE(CheckCSourceCompiles)
+diff --git a/third_party/gloo/CMakeLists.txt b/third_party/gloo/CMakeLists.txt
+index b0db65e69..e9c66400c 100644
+--- a/third_party/gloo/CMakeLists.txt
++++ b/third_party/gloo/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+ 
+ project(gloo CXX C)
+ 
+diff --git a/third_party/psimd/CMakeLists.txt b/third_party/psimd/CMakeLists.txt
+index bd69c6202..4ba1fed29 100644
+--- a/third_party/psimd/CMakeLists.txt
++++ b/third_party/psimd/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
++CMAKE_MINIMUM_REQUIRED(VERSION 3.5 FATAL_ERROR)
+ 
+ INCLUDE(GNUInstallDirs)
+ 
+diff --git a/third_party/tensorpipe/third_party/libuv/CMakeLists.txt b/third_party/tensorpipe/third_party/libuv/CMakeLists.txt
+index 09996d2ab..9c0be8c29 100644
+--- a/third_party/tensorpipe/third_party/libuv/CMakeLists.txt
++++ b/third_party/tensorpipe/third_party/libuv/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ project(libuv LANGUAGES C)
+ 
+ cmake_policy(SET CMP0057 NEW) # Enable IN_LIST operator
+-- 
+2.34.1
+

--- a/recipes-devtools/pytorch/pytorch_2.5.0.bb
+++ b/recipes-devtools/pytorch/pytorch_2.5.0.bb
@@ -13,6 +13,7 @@ SRC_URI += " \
     file://0004-Use-native-protobuf-compiler.patch \
     file://0005-Disable-various-warnings.patch \
     file://0006-Fixups-for-cross-building-in-OE.patch \
+    file://0007-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch \
 "
 
 S = "${UNPACKDIR}/${PN}-v${PV}"

--- a/recipes-devtools/triton/triton-common/0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
+++ b/recipes-devtools/triton/triton-common/0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
@@ -1,0 +1,84 @@
+From bbd34b98a7dffc1b50582f15530763ae280c4de6 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Tue, 19 Aug 2025 13:52:28 +0100
+Subject: [PATCH 2/2] cmake: Set minimum required version to 3.5 for CMake 4+
+ compatibility
+
+Fix:
+
+| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
+|   Compatibility with CMake < 3.5 has been removed from CMake.
+|
+|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+|   to tell CMake that the project requires at least <min> but has been updated
+|   to work with policies introduced by <max> or earlier.
+|
+|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+|
+|
+| -- Configuring incomplete, errors occurred!
+
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ CMakeLists.txt                      | 2 +-
+ protobuf/CMakeLists.txt             | 2 +-
+ src/test/CMakeLists.txt             | 2 +-
+ src/test/triton_json/CMakeLists.txt | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 95ed3f6..6946097 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,7 +24,7 @@
+ # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+-cmake_minimum_required(VERSION 3.17)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(tritoncommon LANGUAGES C CXX)
+ 
+diff --git a/protobuf/CMakeLists.txt b/protobuf/CMakeLists.txt
+index 781a758..c5063ec 100644
+--- a/protobuf/CMakeLists.txt
++++ b/protobuf/CMakeLists.txt
+@@ -24,7 +24,7 @@
+ # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+-cmake_minimum_required (VERSION 3.18)
++cmake_minimum_required(VERSION 3.5)
+ 
+ set(protobuf_MODULE_COMPATIBLE TRUE CACHE BOOL "protobuf_MODULE_COMPATIBLE" FORCE)
+ find_package(Protobuf REQUIRED)
+diff --git a/src/test/CMakeLists.txt b/src/test/CMakeLists.txt
+index f5fd907..c0b3541 100644
+--- a/src/test/CMakeLists.txt
++++ b/src/test/CMakeLists.txt
+@@ -24,7 +24,7 @@
+ # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+-cmake_minimum_required (VERSION 3.18)
++cmake_minimum_required(VERSION 3.5)
+ 
+ find_package(GTest REQUIRED)
+ 
+diff --git a/src/test/triton_json/CMakeLists.txt b/src/test/triton_json/CMakeLists.txt
+index 3ef9311..8ab4d90 100644
+--- a/src/test/triton_json/CMakeLists.txt
++++ b/src/test/triton_json/CMakeLists.txt
+@@ -24,7 +24,7 @@
+ # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+-cmake_minimum_required (VERSION 3.18)
++cmake_minimum_required(VERSION 3.5)
+ add_executable(triton-json-test triton_json_test.cc ../../error.cc)
+ target_link_libraries(
+   triton-json-test
+-- 
+2.34.1
+

--- a/recipes-devtools/triton/triton-common_2.58.0.bb
+++ b/recipes-devtools/triton/triton-common_2.58.0.bb
@@ -6,6 +6,7 @@ SECTION = "libs"
 SRC_URI = "\
     git://github.com/triton-inference-server/common.git;protocol=https;branch=r25.05 \
     file://0001-Build-fixups.patch \
+    file://0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch \
 "
 
 SRCREV = "e4e00edd25af07d2f0e81e2025dbd40daa1dffc2"

--- a/recipes-support/nsync/nsync/0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
+++ b/recipes-support/nsync/nsync/0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
@@ -1,0 +1,39 @@
+From e73b02b1faad6730804eb900a9e50025ffb0cfee Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Tue, 19 Aug 2025 14:52:52 +0100
+Subject: [PATCH 2/2] cmake: Set minimum required version to 3.5 for CMake 4+
+ compatibility
+
+Fix:
+
+| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
+|   Compatibility with CMake < 3.5 has been removed from CMake.
+|
+|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+|   to tell CMake that the project requires at least <min> but has been updated
+|   to work with policies introduced by <max> or earlier.
+|
+|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+|
+|
+| -- Configuring incomplete, errors occurred!
+
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e6a7576..6231e88 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 2.8.12)
++cmake_minimum_required (VERSION 3.5)
+ 
+ # nsync provides portable synchronization primitives, such as mutexes and
+ # condition variables.
+-- 
+2.34.1
+

--- a/recipes-support/nsync/nsync_1.26.0.bb
+++ b/recipes-support/nsync/nsync_1.26.0.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 SRC_URI = " \
     git://github.com/google/nsync.git;protocol=https;branch=master;tag=${PV} \
     file://0001-Export-cmake-config-file.patch \
+    file://0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch \
 "
 SRCREV = "13de152c2a1cd73ff4df97bd2c406b6d15d34af3"
 

--- a/recipes-support/safeint/safeint/0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
+++ b/recipes-support/safeint/safeint/0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
@@ -1,0 +1,39 @@
+From e85e28ac7526ebed658c046e5dfc93fe83db5955 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Tue, 19 Aug 2025 14:43:50 +0100
+Subject: [PATCH 2/2] cmake: Set minimum required version to 3.5 for CMake 4+
+ compatibility
+
+Fix:
+
+| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
+|   Compatibility with CMake < 3.5 has been removed from CMake.
+|
+|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+|   to tell CMake that the project requires at least <min> but has been updated
+|   to work with policies introduced by <max> or earlier.
+|
+|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+|
+|
+| -- Configuring incomplete, errors occurred!
+
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 68cacaf..6dae1eb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.0)
++cmake_minimum_required(VERSION 3.5)
+ 
+ project(SafeInt CXX)
+ 
+-- 
+2.34.1
+

--- a/recipes-support/safeint/safeint_3.0.28.bb
+++ b/recipes-support/safeint/safeint_3.0.28.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=052fd523d0ea51ed2fb75a46627e23bf"
 SRC_URI = " \
     git://github.com/dcleblanc/SafeInt.git;protocol=https;nobranch=1;tag=${PV} \
     file://0001-Updates-for-OE-cross-builds.patch \
+    file://0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch \
 "
 SRCREV = "4cafc9196c4da9c817992b20f5253ef967685bf8"
 

--- a/recipes-support/yaml-cpp/yaml-cpp-070/0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
+++ b/recipes-support/yaml-cpp/yaml-cpp-070/0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch
@@ -1,0 +1,40 @@
+From 371284223eada6e6123dc033b59217452dd379ae Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Tue, 19 Aug 2025 16:22:38 +0100
+Subject: [PATCH 2/2] cmake: Set minimum required version to 3.5 for CMake 4+
+ compatibility
+
+Fix:
+
+| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
+|   Compatibility with CMake < 3.5 has been removed from CMake.
+|
+|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
+|   to tell CMake that the project requires at least <min> but has been updated
+|   to work with policies introduced by <max> or earlier.
+|
+|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+|
+|
+| -- Configuring incomplete, errors occurred!
+
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b230b9e..078e18e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # 3.5 is actually available almost everywhere, but this a good minimum
+-cmake_minimum_required(VERSION 3.4)
++cmake_minimum_required(VERSION 3.5)
+ 
+ # enable MSVC_RUNTIME_LIBRARY target property
+ # see https://cmake.org/cmake/help/latest/policy/CMP0091.html
+-- 
+2.34.1
+

--- a/recipes-support/yaml-cpp/yaml-cpp-070_0.7.0.bb
+++ b/recipes-support/yaml-cpp/yaml-cpp-070_0.7.0.bb
@@ -10,6 +10,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=6a8aaf0595c2efc1a9c2e0913e9c1a2c"
 SRC_URI = " \
     git://github.com/jbeder/yaml-cpp.git;branch=master;protocol=https;tag=yaml-cpp-${PV} \
     file://0001-Updates-for-OE-cross-builds.patch \
+    file://0002-cmake-Set-minimum-required-version-to-3.5-for-CMake-.patch \
 "
 SRCREV = "0579ae3d976091d7d664aa9d2527e0d0cff25763"
 


### PR DESCRIPTION
Those commits fixes the following issue:

```
| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
|   Compatibility with CMake < 3.5 has been removed from CMake.
|
|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
|   to tell CMake that the project requires at least <min> but has been updated
|   to work with policies introduced by <max> or earlier.
|
|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
|
|
| -- Configuring incomplete, errors occurred!
```