### PR TITLE
Add support for onnxruntime python bindings

### DIFF
--- a/recipes-devtools/onnx/onnx_1.17.0.bb
+++ b/recipes-devtools/onnx/onnx_1.17.0.bb
@@ -27,4 +27,8 @@ EXTRA_OECMAKE = " \
     -DONNX_DISABLE_STATIC_REGISTRATION=ON \
 "
 
-INSANE_SKIP:${PN}-dev = "buildpaths"
+do_install:append() {
+    # remove lines with tmpdir references, they're harmful when we build against this later
+    sed -i '/CMAKE_PREFIX_PATH/d' ${D}${libdir}/cmake/ONNX/ONNXConfig.cmake
+    sed -i '/Protobuf_INCLUDE_DIR/d' ${D}${libdir}/cmake/ONNX/ONNXConfig.cmake
+}


### PR DESCRIPTION
I've also included a commit I needed to add for the master branch to fix building the onnx dependency.

With this now the python bindings for onnxruntime can be loaded, e.g. 

```
# python3 -c "import onnxruntime"
```