### PR TITLE
pytorch: use python3-native instead of host python

### DIFF
--- a/recipes-devtools/pytorch/pytorch_2.5.0.bb
+++ b/recipes-devtools/pytorch/pytorch_2.5.0.bb
@@ -20,7 +20,7 @@ S = "${UNPACKDIR}/${PN}-v${PV}"
 
 COMPATIBLE_MACHINE = "(cuda)"
 
-inherit cmake cuda
+inherit cmake cuda python3native
 
 EXTRA_OECMAKE += " \
     -DGLIBCXX_USE_CXX11_ABI=1 \
@@ -97,6 +97,8 @@ DEPENDS += " \
     cudnn \
     protobuf \
     protobuf-native \
+    python3-pyyaml-native \
+    python3-typing-extensions-native \
 "
 
 FILES:${PN} += " \


### PR DESCRIPTION
When building this recipe, it errored out because it was using python3 from `/usr/bin` on my machine which was too out of date.

With this change, it will now properly use the yocto provided host python, which in my case is a new enough version that the build can now succeed.