### PR TITLE
Remove python3-pkg-resources from pycuda dependencies

### DIFF
--- a/recipes-devtools/python/python3-pycuda_2026.1.bb
+++ b/recipes-devtools/python/python3-pycuda_2026.1.bb
@@ -35,7 +35,6 @@ RDEPENDS:${PN} += "\
     python3-math \
     python3-numbers \
     python3-numpy \
-    python3-pkg-resources \
     python3-py \
     python3-six \
     cuda-nvcc \


### PR DESCRIPTION
python3-pkg-resources does not exist in Wrynose anymore.