### PR TITLE
conf/layer.conf: update LAYERSERIESCOMPAT with wrynose

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PRIORITY_tegra-community = "20"
 
 LAYERVERSION_tegra-community = "1"
 LAYERDEPENDS_tegra-community = "core tegra openembedded-layer meta-python"
-LAYERSERIES_COMPAT_tegra-community = "blacksail"
+LAYERSERIES_COMPAT_tegra-community = "wrynose blacksail"


### PR DESCRIPTION
When Nvidia is releasing Jetpack 39.2.0 with Yocto support quite close in time with the release of Yocto 6.0, that is a LTS release, I think it will be quite common to use them together. Let us aim for compatibility of the two until we need to branch them out.