### PR TITLE
gstreamer-tests: drop unsupported nvv4l2decoder properties from sinte…

### DIFF
--- a/recipes-test/tegra-tests/gstreamer-tests/sinteltest.sh.in
+++ b/recipes-test/tegra-tests/gstreamer-tests/sinteltest.sh.in
@@ -4,4 +4,4 @@
 
 gst-launch-1.0 filesrc location=@DATADIR@/gstreamer-tests/sintel_trailer-1080p.mp4 ! qtdemux name=demux \
 	       demux.audio_0 ! queue ! faad ! $AUDIOSINK \
-	       demux.video_0 ! queue ! h264parse ! nvv4l2decoder enable-max-performance=1 enable-frame-type-reporting=1 $TRANSFORM ! $VIDEOSINK
+	       demux.video_0 ! queue ! h264parse ! nvv4l2decoder $TRANSFORM ! $VIDEOSINK


### PR DESCRIPTION
On L4T R39.2.0 the nvvideo4linux2 nvv4l2decoder element no longer exposes the `enable-max-performance` and `enable-frame-type-reporting` properties, so sinteltest aborts at parse time with:

  WARNING: erroneous pipeline: no property "enable-max-performance" in
  element "nvv4l2decoder"

Both properties are absent from `gst-inspect-1.0 nvv4l2decoder` on this release. Dropping them lets the pipeline parse and the Sintel trailer decode end-to-end through nvv4l2decoder.