### PR TITLE
vpi-tests: remove version number, fix Orin Nano failures

### DIFF
--- a/recipes-test/tegra-tests/vpi-tests/run-vpi-tests.sh
+++ b/recipes-test/tegra-tests/vpi-tests/run-vpi-tests.sh
@@ -192,6 +192,12 @@ find_test() {
 
 jetson_clocks
 
+
+# Orin Nano does not have PVA
+pva_supported=
+if [ -c /dev/nvhost-ctrl-pva0 ]; then
+    pva_supported="yes"
+fi
 testcount=0
 testpass=0
 testfail=0
@@ -208,6 +214,9 @@ for cand in $tests_to_run; do
     else
         declare -n backendList=$t
         for backend in ${backendList[@]}; do
+	    if echo "$backend" | grep -q "pva" && [ -z "$pva_supported" ]; then
+		continue
+	    fi
             testcount=$((testcount+1))
             echo "=== BEGIN: $t ==="
             if run_$t $backend; then

--- a/recipes-test/tegra-tests/vpi-tests_1.0.bb
+++ b/recipes-test/tegra-tests/vpi-tests_1.0.bb
@@ -3,7 +3,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
 SRC_URI = "\
-    file://run-vpi4-tests.sh \
+    file://run-vpi-tests.sh \
 "
 
 S = "${UNPACKDIR}"
@@ -12,8 +12,10 @@ COMPATIBLE_MACHINE = "(tegra)"
 
 do_install() {
     install -d ${D}${bindir}
-    install -m 0755 ${UNPACKDIR}/run-vpi4-tests.sh ${D}${bindir}/run-vpi4-tests
+    install -m 0755 ${UNPACKDIR}/run-vpi-tests.sh ${D}${bindir}/run-vpi-tests
+    ln -s run-vpi-tests ${D}${bindir}/run-vpi4-tests
 }
 
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"
 RDEPENDS:${PN} = "vpi4-samples tegra-tools-jetson-clocks"
+RPROVIDES:${PN} += "vpi4-tests"


### PR DESCRIPTION
* Remove the version number from the script name and recipe name, so we don't have to change every single downstream reference to these tests every single time NVIDIA updates VPI itself. But for now, keep aliases with the version number included; we can drop that when VPI5 comes around.

* Fix the test script so it silently skips running any sample that has a PVA dependency when the device for controlling the PVA is missing. Orin Nano targets do not have a PVA, and the reported failures were misleading.