### PR TITLE
Add Holoscan Sensor Bridge v2.6.0

### DIFF
--- a/recipes-devtools/holoscan/holoscan-sensor-bridge/0001-Updates-for-OE-cross-builds.patch
+++ b/recipes-devtools/holoscan/holoscan-sensor-bridge/0001-Updates-for-OE-cross-builds.patch
@@ -1,0 +1,127 @@
+From 2ea8c686f0398c36ca50122fdbb26b1cd34d13f0 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Tue, 30 Jun 2026 08:22:00 -0700
+Subject: [PATCH] Updates for OE cross builds
+
+Upstream-Status: Inappropriate [oe-specific]
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ cmake/sipl_api.cmake                             |  5 ++++-
+ src/hololink/common/CMakeLists.txt               | 10 +++++++---
+ src/hololink/operators/iq_dec/CMakeLists.txt     |  3 ++-
+ src/hololink/operators/iq_enc/CMakeLists.txt     |  3 ++-
+ src/hololink/operators/sig_gen/CMakeLists.txt    |  3 ++-
+ src/hololink/operators/sig_viewer/CMakeLists.txt |  2 +-
+ 6 files changed, 18 insertions(+), 8 deletions(-)
+
+diff --git a/cmake/sipl_api.cmake b/cmake/sipl_api.cmake
+index d4e7cf3..d16f186 100644
+--- a/cmake/sipl_api.cmake
++++ b/cmake/sipl_api.cmake
+@@ -18,7 +18,10 @@ include_guard(GLOBAL)
+ # Detect SIPL API version from the L4T major version.
+ # Check L4T_MAJ_VER env var first (set in Docker builds); fall back to
+ # parsing /sys/class/dmi/id/bios_version on the host.
+-if(DEFINED ENV{L4T_MAJ_VER})
++if(DEFINED L4T_MAJ_VER)
++    set(_l4t_major_raw "${L4T_MAJ_VER}")
++    message(STATUS "L4T major version (from CMake): ${_l4t_major_raw}")
++elseif(DEFINED ENV{L4T_MAJ_VER})
+     set(_l4t_major_raw "$ENV{L4T_MAJ_VER}")
+     message(STATUS "L4T major version (from environment): ${_l4t_major_raw}")
+ else()
+diff --git a/src/hololink/common/CMakeLists.txt b/src/hololink/common/CMakeLists.txt
+index 45cf9dc..87720aa 100644
+--- a/src/hololink/common/CMakeLists.txt
++++ b/src/hololink/common/CMakeLists.txt
+@@ -32,6 +32,11 @@ target_include_directories(hololink
+     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+   )
+ 
++target_include_directories(hololink
++  PUBLIC
++    ${IMGUI_SOURCE_DIR}
++)
++
+ if(TARGET CUDA::nvtx3)
+   set(CUDA_NVTX_TARGET CUDA::nvtx3)
+ else()
+@@ -42,15 +47,14 @@ target_link_libraries(hololink
+   PRIVATE
+     holoscan::core
+ 
+-    # Required by the gui_renderer
+-    holoscan::viz
+-    holoscan::viz::imgui
+   PUBLIC
+     hololink::core
+     CUDA::cuda_driver
+     CUDA::nvrtc
+     ${CUDA_NVTX_TARGET}
+     fmt::fmt-header-only
++    holoscan::viz
++    holoviz_imgui
+   )
+ 
+ if (HOLOLINK_BUILD_ROCE)
+diff --git a/src/hololink/operators/iq_dec/CMakeLists.txt b/src/hololink/operators/iq_dec/CMakeLists.txt
+index babab8e..8f87754 100644
+--- a/src/hololink/operators/iq_dec/CMakeLists.txt
++++ b/src/hololink/operators/iq_dec/CMakeLists.txt
+@@ -32,7 +32,8 @@ target_link_libraries(iq_dec
+   PRIVATE
+     hololink
+     holoscan::core
+-    holoscan::viz::imgui
++  PUBLIC
++    holoviz_imgui
+ )
+ 
+ # Installation of the iq_dec operator
+diff --git a/src/hololink/operators/iq_enc/CMakeLists.txt b/src/hololink/operators/iq_enc/CMakeLists.txt
+index 99ef8da..f8e03a9 100644
+--- a/src/hololink/operators/iq_enc/CMakeLists.txt
++++ b/src/hololink/operators/iq_enc/CMakeLists.txt
+@@ -32,7 +32,8 @@ target_link_libraries(iq_enc
+   PRIVATE
+     hololink
+     holoscan::core
+-    holoscan::viz::imgui
++  PUBLIC
++    holoviz_imgui
+ )
+ 
+ # Installation of the iq_enc operator
+diff --git a/src/hololink/operators/sig_gen/CMakeLists.txt b/src/hololink/operators/sig_gen/CMakeLists.txt
+index 87650dc..7456536 100644
+--- a/src/hololink/operators/sig_gen/CMakeLists.txt
++++ b/src/hololink/operators/sig_gen/CMakeLists.txt
+@@ -48,7 +48,8 @@ target_link_libraries(sig_gen
+     hololink
+     hololink::expr_eval
+     holoscan::core
+-    holoscan::viz::imgui
++  PUBLIC
++    holoviz_imgui
+ )
+ 
+ # Installation of the sig_gen operator
+diff --git a/src/hololink/operators/sig_viewer/CMakeLists.txt b/src/hololink/operators/sig_viewer/CMakeLists.txt
+index ba197cf..ef20d0c 100644
+--- a/src/hololink/operators/sig_viewer/CMakeLists.txt
++++ b/src/hololink/operators/sig_viewer/CMakeLists.txt
+@@ -37,10 +37,10 @@ target_link_libraries(sig_viewer
+     hololink
+     hololink::core
+     holoscan::core
++    holoviz_imgui
+   PRIVATE
+     CUDA::cufft
+     CUDA::cuda_driver
+-    holoscan::viz::imgui
+ )
+ 
+ # Installation of the sig_viewer operator
+-- 
+2.43.0
+

--- a/recipes-devtools/holoscan/holoscan-sensor-bridge/10-hololink-mgbe0_0.network
+++ b/recipes-devtools/holoscan/holoscan-sensor-bridge/10-hololink-mgbe0_0.network
@@ -1,0 +1,16 @@
+[Match]
+Name=mgbe0_0
+
+[Link]
+MTUBytes=9000
+RequiredForOnline=no
+
+[Network]
+ConfigureWithoutCarrier=yes
+Address=192.168.0.101/24
+DHCP=no
+LinkLocalAddressing=no
+IPv6AcceptRA=no
+LLDP=no
+EmitLLDP=no
+MulticastDNS=no

--- a/recipes-devtools/holoscan/holoscan-sensor-bridge_2.6.0.bb
+++ b/recipes-devtools/holoscan/holoscan-sensor-bridge_2.6.0.bb
@@ -1,0 +1,85 @@
+SUMMARY = "NVIDIA Holoscan Sensor Bridge - Bring Your Own Sensor (BYOS) over Ethernet"
+HOMEPAGE = "https://github.com/nvidia-holoscan/holoscan-sensor-bridge"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+SRC_URI = "\
+    git://github.com/nvidia-holoscan/holoscan-sensor-bridge.git;protocol=https;nobranch=1;tag=${PV} \
+    file://0001-Updates-for-OE-cross-builds.patch \
+    file://10-hololink-mgbe0_0.network \
+"
+SRCREV = "f54091ba594bc936ade41dd78a531d82724d842e"
+
+DEPENDS += " \
+    tegra-libraries-camera \
+    tegra-libraries-nvsci \
+    holoscan-sdk \
+    nvcomp \
+"
+
+inherit cmake cuda setuptools3-base features_check
+
+PACKAGECONFIG ??= "socket fusa examples"
+PACKAGECONFIG[socket] = "-DHOLOLINK_BUILD_SOCKET=ON,-DHOLOLINK_BUILD_SOCKET=OFF"
+PACKAGECONFIG[fusa] = "-DHOLOLINK_BUILD_FUSA=ON,-DHOLOLINK_BUILD_FUSA=OFF,jetson-sipl-api"
+PACKAGECONFIG[roce] = "-DHOLOLINK_BUILD_ROCE=ON,-DHOLOLINK_BUILD_ROCE=OFF,libibverbs1 ibverbs-providers"
+PACKAGECONFIG[examples] = "-DHOLOLINK_BUILD_EXAMPLES=ON, -DHOLOLINK_BUILD_EXAMPLES=OFF"
+PACKAGECONFIG[tests] = "-DHOLOLINK_BUILD_TESTS=ON,-DHOLOLINK_BUILD_TESTS=OFF"
+PACKAGECONFIG[tools] = "-DHOLOLINK_BUILD_TOOLS=ON,-DHOLOLINK_BUILD_TOOLS=OFF,curl"
+PACKAGECONFIG[python] = "-DHOLOLINK_BUILD_PYTHON=ON,-DHOLOLINK_BUILD_PYTHON=OFF"
+
+# HSB: Holoscan Sensor Bridge
+HSB_INSTALL_PATH = "/opt/nvidia/hololink"
+
+EXTRA_OECMAKE:append = " \
+    -DL4T_MAJ_VER=39 \
+    -DCMAKE_INSTALL_PREFIX=${HSB_INSTALL_PATH} \
+    -DIMGUI_SOURCE_DIR=${RECIPE_SYSROOT}/opt/nvidia/imgui \
+"
+
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+do_install:append() {
+    if "${@bb.utils.contains('PACKAGECONFIG', 'socket', 'true', 'false', d)}"; then
+        install -d ${D}${sysconfdir}/sysctl.d
+        echo "net.core.rmem_max = 31326208" > ${D}${sysconfdir}/sysctl.d/52-hololink-rmem_max.conf
+    fi
+
+    if "${@bb.utils.contains('PACKAGECONFIG', 'fusa', 'true', 'false', d)}"; then
+        install -d ${D}${sysconfdir}/systemd/network
+        install -m 0644 ${UNPACKDIR}/10-hololink-mgbe0_0.network ${D}${sysconfdir}/systemd/network/
+    fi
+    install -d ${D}${HSB_INSTALL_PATH}/config
+    install -m 0644 ${S}/examples/example_configuration.yaml ${D}${HSB_INSTALL_PATH}/config
+    rm -rf ${D}${HSB_INSTALL_PATH}/scripts
+}
+
+
+
+FILES:${PN} += " \
+    ${HSB_INSTALL_PATH} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'fusa', '${sysconfdir}/systemd/network', '', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'socket', '${sysconfdir}/sysctl.d', '', d)} \
+"
+
+FILES:${PN}-dev += " \
+    ${HSB_INSTALL_PATH}/include \
+    ${HSB_INSTALL_PATH}/lib/cmake \
+"
+
+FILES:${PN}-staticdev += " \
+    ${HSB_INSTALL_PATH}/lib/*.a \
+"
+
+SYSROOT_DIRS = " \
+    ${HSB_INSTALL_PATH} \
+"
+
+RDEPENDS:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'roce', 'ethtool bash', '', d)}"
+
+INSANE_SKIP:${PN} += "buildpaths"
+INSANE_SKIP:${PN}-staticdev += "buildpaths"
+INSANE_SKIP:${PN}-dbg += "buildpaths"
+INSANE_SKIP:${PN}-dev += "buildpaths"

--- a/recipes-devtools/nvcomp/nvcomp_5.2.0.10.bb
+++ b/recipes-devtools/nvcomp/nvcomp_5.2.0.10.bb
@@ -1,0 +1,30 @@
+SUMMARY = "nvCOMP library provides fast lossless data compression and decompression using a GPU"
+HOMEPAGE = "https://docs.nvidia.com/cuda/nvcomp"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://nvcomp-linux-sbsa-${PV}_cuda13-archive/LICENSE;md5=85649c377f72fda614b170fb9e1216f3"
+
+COMPATIBLE_MACHINE = "(cuda)"
+
+SRC_URI = "https://developer.download.nvidia.com/compute/nvcomp/redist/nvcomp/linux-sbsa/nvcomp-linux-sbsa-${PV}_cuda13-archive.tar.xz;subdir=${BP}"
+SRC_URI[sha256sum] = "c7a7eaabb03ac9893144787cdb41c9c838d9af76124e2f3246f7e20ebbd8b9cc"
+
+do_install () {
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/nvcomp-linux-sbsa-${PV}_cuda13-archive/bin/nvlzcat ${D}${bindir}/
+    install -d ${D}${includedir}
+    cp -rd --no-preserve=ownership ${S}/nvcomp-linux-sbsa-${PV}_cuda13-archive/include/* ${D}${includedir}/
+    install -d ${D}${libdir}
+    cp -rd --no-preserve=ownership ${S}/nvcomp-linux-sbsa-${PV}_cuda13-archive/lib/cmake ${D}${libdir}/
+    install -m 0644 ${S}/nvcomp-linux-sbsa-${PV}_cuda13-archive/lib/libnvcomp_cpu.so.5.2.0.10 ${D}${libdir}/
+    install -m 0644 ${S}/nvcomp-linux-sbsa-${PV}_cuda13-archive/lib/libnvcomp_cpu_static.a ${D}${libdir}/
+    install -m 0644 ${S}/nvcomp-linux-sbsa-${PV}_cuda13-archive/lib/libnvcomp.so.5.2.0.10 ${D}${libdir}/
+    install -m 0644 ${S}/nvcomp-linux-sbsa-${PV}_cuda13-archive/lib/libnvcomp_static.a ${D}${libdir}/
+    ln -s libnvcomp_cpu.so.5 ${D}${libdir}/libnvcomp_cpu.so
+    ln -s libnvcomp.so.5.2.0.10 ${D}${libdir}/libnvcomp_cpu.so.5
+    ln -s libnvcomp.so.5 ${D}${libdir}/libnvcomp.so
+    ln -s libnvcomp_cpu.so.5.2.0.10 ${D}${libdir}/libnvcomp.so.5
+}
+
+SYSROOT_DIRS:append = " ${bindir}"
+
+INSANE_SKIP:${PN} = "already-stripped"


### PR DESCRIPTION
* Tests were done on `Jetson AGX Thor` with [Leopard imaging VB1940 Eagle Camera](https://docs.nvidia.com/holoscan/sensor-bridge/latest/sensor_bridge_hardware_setup.html#sd-tab-item-2) and [Lattice CPNX100-ETH-SENSOR-BRIDGE](https://docs.nvidia.com/holoscan/sensor-bridge/latest/sensor_bridge_hardware_setup.html#sd-tab-item-0)
* Kindly see the results below 

*  Leopard imaging VB1940 Eagle Camera
```
root@jetson-agx-thor-devkit:/opt/nvidia/hololink# DISPLAY=:0 ./bin/fusa_coe_vb1940_player 
INFO 0.0000 hololink.cpp:2710 configure_hsb tid=0x75f -- HSB IP version=0x2603 datecode=0x383bffc2
INFO 1.1138 hololink.cpp:2710 configure_hsb tid=0x75f -- HSB IP version=0x2603 datecode=0x383bffc2
INFO 1.6770 native_vb1940_sensor.cpp:130 configure tid=0x75f -- version=1
INFO 3.5593 native_vb1940_sensor.cpp:130 configure tid=0x75f -- version=1
[warning] [application.cpp:549] Current stack size limit (8388608 bytes / 8192 KB) is below the recommended minimum (33554432 bytes / 32768 KB). Consider increasing it with 'ulimit -s 32768'. For Docker, use '--ulimit stack=33554432'
[info] [fragment.cpp:1142] Loading extensions from configs...
[info] [fusa_coe_vb1940_player.cpp:91] Using interface=mgbe0_0, mac=8C:1F:64:6D:70:EF
INFO 5.3685 fusa_coe_capture.cpp:310 configure tid=0x75f -- start=3200, bytes_per_line=3456, width=2560, height=1984, format=1, trailing_bytes=6400
INFO 5.3685 packed_format_converter.cpp:262 configure tid=0x75f -- start_byte=0, bytes_per_line=3456, width=2560, height=1984, trailing_bytes=0
[info] [gxf_executor.cpp:566] Creating context
INFO 5.3731 fusa_coe_capture.cpp:310 configure tid=0x75f -- start=3200, bytes_per_line=3456, width=2560, height=1984, format=1, trailing_bytes=6400
INFO 5.3731 packed_format_converter.cpp:262 configure tid=0x75f -- start_byte=0, bytes_per_line=3456, width=2560, height=1984, trailing_bytes=0
[info] [gxf_executor.cpp:2780] Activating Graph...
[info] [entity_pool.cpp:134] EntityPool::GetShared: created new shared pool for context 0xaaaabac7a820 with capacity 256
[info] [gxf_executor.cpp:2921] Running Graph...
[info] [gxf_executor.cpp:2923] Waiting for completion...
[info] [greedy_scheduler.cpp:191] Scheduling 9 entities
INFO 5.8836 fusa_coe_capture.cpp:107 start tid=0x767 -- Opened NvFusaCapture channel 4
INFO 5.8837 data_channel.cpp:248 configure_coe tid=0x767 -- Enabling 1722 COE: channel=4, frame_size=6866304, pixel_width=3456
INFO 5.8849 data_channel.cpp:142 compute_payload_size tid=0x767 -- mtu=1500 overhead=46 payload_size=1408 packets=4877
INFO 6.5378 fusa_coe_capture.cpp:107 start tid=0x767 -- Opened NvFusaCapture channel 5
INFO 6.5380 data_channel.cpp:248 configure_coe tid=0x767 -- Enabling 1722 COE: channel=5, frame_size=6866304, pixel_width=3456
INFO 6.5392 data_channel.cpp:142 compute_payload_size tid=0x767 -- mtu=1500 overhead=46 payload_size=1408 packets=4877
[info] [context.cpp:54] _______________
[info] [context.cpp:54] Vulkan Version:
[info] [context.cpp:54]  - available:  1.4.350
[info] [context.cpp:54]  - requesting: 1.2.0
[info] [context.cpp:54] ______________________
[info] [context.cpp:54] Used Instance Layers :
[info] [context.cpp:54] 
[info] [context.cpp:54] Used Instance Extensions :
[info] [context.cpp:54] VK_KHR_surface
[info] [context.cpp:54] VK_KHR_xcb_surface
[info] [context.cpp:54] VK_KHR_display
[info] [context.cpp:54] VK_EXT_display_surface_counter
[info] [context.cpp:54] VK_EXT_debug_utils
[info] [context.cpp:54] VK_KHR_external_memory_capabilities
[info] [context.cpp:54] VK_KHR_surface
[info] [context.cpp:54] VK_KHR_get_surface_capabilities2
[info] [context.cpp:54] ____________________
[info] [context.cpp:54] Compatible Devices :
[info] [context.cpp:54] 0: NVIDIA Thor
[info] [context.cpp:54] Physical devices found : 
[info] [context.cpp:54] 1
[info] [context.cpp:54] ________________________
[info] [context.cpp:54] Used Device Extensions :
[info] [context.cpp:54] VK_KHR_swapchain
[info] [context.cpp:54] VK_EXT_display_control
[info] [context.cpp:54] VK_KHR_external_memory
[info] [context.cpp:54] VK_KHR_external_memory_fd
[info] [context.cpp:54] VK_KHR_external_semaphore
[info] [context.cpp:54] VK_KHR_external_semaphore_fd
[info] [context.cpp:54] VK_KHR_push_descriptor
[info] [context.cpp:54] VK_EXT_line_rasterization
[info] [context.cpp:54] VK_KHR_sampler_ycbcr_conversion
[info] [context.cpp:54] VK_EXT_present_mode_fifo_latest_ready
[info] [context.cpp:54] 
[info] [vulkan_app.cpp:572] Using device 0: NVIDIA Thor (UUID a7c66ad26dbbab8c1a237ba6dba360)
[info] [framebuffer_sequence.cpp:150] Using surface format 'B8G8R8A8Unorm, SrgbNonlinear'
[info] [framebuffer_sequence.cpp:170] Using depth format 'D32Sfloat'
[info] [framebuffer_sequence.cpp:360] Using present mode 'Immediate'
[info] [framebuffer_sequence.cpp:150] Using surface format 'B8G8R8A8Srgb, SrgbNonlinear'
[info] [framebuffer_sequence.cpp:170] Using depth format 'D32Sfloat'
[info] [framebuffer_sequence.cpp:360] Using present mode 'Immediate'
[info] [framebuffer_sequence.cpp:360] Using present mode 'Immediate'
[info] [holoviz.cpp:2271] Input spec:
- type: color
  name: 0
  opacity: 1.000000
  priority: 0
  image_format: r16g16b16a16_unorm
  views:
    - offset_x: 0
      offset_y: 0
      width: 0.5
      height: 1
- type: color
  name: 1
  opacity: 1.000000
  priority: 0
  image_format: r16g16b16a16_unorm
  views:
    - offset_x: 0.5
      offset_y: 0
      width: 0.5
      height: 1

[info] [greedy_scheduler.cpp:405] Scheduler stopped: Some entities are waiting for execution, but there are no periodic or async entities to get out of the deadlock.
[info] [greedy_scheduler.cpp:435] Scheduler finished.
[info] [gxf_executor.cpp:2930] Deactivating Graph...
[info] [gxf_executor.cpp:2939] Graph execution finished.
[info] [gxf_executor.cpp:601] Destroying context
root@jetson-agx-thor-devkit:/opt/nvidia/hololink#
```

* Lattice CPNX100-ETH-SENSOR-BRIDGE
```
root@jetson-agx-thor-devkit:/opt/nvidia/hololink# DISPLAY=:0 ./bin/fusa_coe_imx274_player 
INFO 0.0000 hololink.cpp:2710 configure_hsb tid=0x77e -- HSB IP version=0x2603 datecode=0x38f20a67
INFO 2.1140 hololink.cpp:2710 configure_hsb tid=0x77e -- HSB IP version=0x2603 datecode=0x38f20a67
INFO 2.6780 native_imx274_sensor.cpp:60 configure tid=0x77e -- version=1
INFO 3.1501 native_imx274_sensor.cpp:60 configure tid=0x77e -- version=1
[warning] [application.cpp:549] Current stack size limit (8388608 bytes / 8192 KB) is below the recommended minimum (33554432 bytes / 32768 KB). Consider increasing it with 'ulimit -s 32768'. For Docker, use '--ulimit stack=33554432'
[info] [fragment.cpp:1142] Loading extensions from configs...
[info] [fusa_coe_imx274_player.cpp:125] Using interface=mgbe0_0, mac=48:B0:2D:EE:85:38
INFO 3.6239 fusa_coe_capture.cpp:310 configure tid=0x77e -- start=20672, bytes_per_line=2560, width=1920, height=1080, format=1, trailing_bytes=0
INFO 3.6240 packed_format_converter.cpp:262 configure tid=0x77e -- start_byte=0, bytes_per_line=2560, width=1920, height=1080, trailing_bytes=0
[info] [gxf_executor.cpp:566] Creating context
INFO 3.6281 fusa_coe_capture.cpp:310 configure tid=0x77e -- start=20672, bytes_per_line=2560, width=1920, height=1080, format=1, trailing_bytes=0
INFO 3.6281 packed_format_converter.cpp:262 configure tid=0x77e -- start_byte=0, bytes_per_line=2560, width=1920, height=1080, trailing_bytes=0
[info] [gxf_executor.cpp:2780] Activating Graph...
[info] [entity_pool.cpp:134] EntityPool::GetShared: created new shared pool for context 0xaaaaf9bef350 with capacity 256
[info] [gxf_executor.cpp:2921] Running Graph...
[info] [gxf_executor.cpp:2923] Waiting for completion...
[info] [greedy_scheduler.cpp:191] Scheduling 9 entities
INFO 4.1096 fusa_coe_capture.cpp:107 start tid=0x78b -- Opened NvFusaCapture channel 4
INFO 4.1097 data_channel.cpp:248 configure_coe tid=0x78b -- Enabling 1722 COE: channel=4, frame_size=2785472, pixel_width=2560
INFO 4.1109 data_channel.cpp:142 compute_payload_size tid=0x78b -- mtu=1500 overhead=46 payload_size=1408 packets=1979
INFO 4.4877 fusa_coe_capture.cpp:107 start tid=0x78b -- Opened NvFusaCapture channel 5
INFO 4.4878 data_channel.cpp:248 configure_coe tid=0x78b -- Enabling 1722 COE: channel=5, frame_size=2785472, pixel_width=2560
INFO 4.4889 data_channel.cpp:142 compute_payload_size tid=0x78b -- mtu=1500 overhead=46 payload_size=1408 packets=1979
[info] [context.cpp:54] _______________
[info] [context.cpp:54] Vulkan Version:
[info] [context.cpp:54]  - available:  1.4.350
[info] [context.cpp:54]  - requesting: 1.2.0
[info] [context.cpp:54] ______________________
[info] [context.cpp:54] Used Instance Layers :
[info] [context.cpp:54] 
[info] [context.cpp:54] Used Instance Extensions :
[info] [context.cpp:54] VK_KHR_surface
[info] [context.cpp:54] VK_KHR_xcb_surface
[info] [context.cpp:54] VK_KHR_display
[info] [context.cpp:54] VK_EXT_display_surface_counter
[info] [context.cpp:54] VK_EXT_debug_utils
[info] [context.cpp:54] VK_KHR_external_memory_capabilities
[info] [context.cpp:54] VK_KHR_surface
[info] [context.cpp:54] VK_KHR_get_surface_capabilities2
[info] [context.cpp:54] ____________________
[info] [context.cpp:54] Compatible Devices :
[info] [context.cpp:54] 0: NVIDIA Thor
[info] [context.cpp:54] Physical devices found : 
[info] [context.cpp:54] 1
[info] [context.cpp:54] ________________________
[info] [context.cpp:54] Used Device Extensions :
[info] [context.cpp:54] VK_KHR_swapchain
[info] [context.cpp:54] VK_EXT_display_control
[info] [context.cpp:54] VK_KHR_external_memory
[info] [context.cpp:54] VK_KHR_external_memory_fd
[info] [context.cpp:54] VK_KHR_external_semaphore
[info] [context.cpp:54] VK_KHR_external_semaphore_fd
[info] [context.cpp:54] VK_KHR_push_descriptor
[info] [context.cpp:54] VK_EXT_line_rasterization
[info] [context.cpp:54] VK_KHR_sampler_ycbcr_conversion
[info] [context.cpp:54] VK_EXT_present_mode_fifo_latest_ready
[info] [context.cpp:54] 
[info] [vulkan_app.cpp:572] Using device 0: NVIDIA Thor (UUID a7c66ad26dbbab8c1a237ba6dba360)
[info] [framebuffer_sequence.cpp:150] Using surface format 'B8G8R8A8Unorm, SrgbNonlinear'
[info] [framebuffer_sequence.cpp:170] Using depth format 'D32Sfloat'
[info] [framebuffer_sequence.cpp:360] Using present mode 'Immediate'
[info] [framebuffer_sequence.cpp:150] Using surface format 'B8G8R8A8Srgb, SrgbNonlinear'
[info] [framebuffer_sequence.cpp:170] Using depth format 'D32Sfloat'
[info] [framebuffer_sequence.cpp:360] Using present mode 'Immediate'
[info] [framebuffer_sequence.cpp:360] Using present mode 'Immediate'
[info] [holoviz.cpp:2271] Input spec:
- type: color
  name: 0
  opacity: 1.000000
  priority: 0
  image_format: r16g16b16a16_unorm
  views:
    - offset_x: 0
      offset_y: 0
      width: 0.5
      height: 1
- type: color
  name: 1
  opacity: 1.000000
  priority: 0
  image_format: r16g16b16a16_unorm
  views:
    - offset_x: 0.5
      offset_y: 0
      width: 0.5
      height: 1

[info] [greedy_scheduler.cpp:405] Scheduler stopped: Some entities are waiting for execution, but there are no periodic or async entities to get out of the deadlock.
[info] [greedy_scheduler.cpp:435] Scheduler finished.
[info] [gxf_executor.cpp:2930] Deactivating Graph...
[info] [gxf_executor.cpp:2939] Graph execution finished.
[info] [gxf_executor.cpp:601] Destroying context
root@jetson-agx-thor-devkit:/opt/nvidia/hololink#
```

```
root@jetson-agx-thor-devkit:/opt/nvidia/hololink# DISPLAY=:0 ./bin/linux_single_network_stereo_imx274_player --configuration=/opt/nvidia/hololink/config/example_configuration.yaml 
INFO 0.0000 hololink.cpp:2710 configure_hsb tid=0x7d9 -- HSB IP version=0x2603 datecode=0x38f20a67
INFO 1.1133 hololink.cpp:2710 configure_hsb tid=0x7d9 -- HSB IP version=0x2603 datecode=0x38f20a67
INFO 1.7551 native_imx274_sensor.cpp:60 configure tid=0x7d9 -- version=1
INFO 2.2374 native_imx274_sensor.cpp:60 configure tid=0x7d9 -- version=1
[warning] [application.cpp:549] Current stack size limit (8388608 bytes / 8192 KB) is below the recommended minimum (33554432 bytes / 32768 KB). Consider increasing it with 'ulimit -s 32768'. For Docker, use '--ulimit stack=33554432'
[info] [fragment.cpp:1142] Loading extensions from configs...
[info] [gxf_executor.cpp:566] Creating context
INFO 2.8800 csi_to_bayer.cpp:340 configure tid=0x7d9 -- start_byte=19376, bytes_per_line=2400, pixel_width=1920, pixel_height=1080, pixel_format=1, trailing_bytes=0.
INFO 2.8800 csi_to_bayer.cpp:340 configure tid=0x7d9 -- start_byte=19376, bytes_per_line=2400, pixel_width=1920, pixel_height=1080, pixel_format=1, trailing_bytes=0.
[info] [gxf_executor.cpp:2780] Activating Graph...
[info] [entity_pool.cpp:134] EntityPool::GetShared: created new shared pool for context 0xaaaaf148cd50 with capacity 256
[info] [gxf_executor.cpp:2921] Running Graph...
[info] [gxf_executor.cpp:2923] Waiting for completion...
[info] [greedy_scheduler.cpp:191] Scheduling 9 entities
INFO 2.8912 data_channel.cpp:399 configure_socket tid=0x7e1 -- (done) DataChannel configure_socket socket_fd=49 local_ip=192.168.0.101.
INFO 2.8927 data_channel.cpp:559 ReceiverMemoryDescriptor tid=0x7e1 -- Using pinned host memory: host_ptr=0x332400000 device_ptr=0x332400000 size=0x27e000
INFO 2.8928 linux_receiver_op.cpp:150 start_receiver tid=0x7e1 -- local_ip=192.168.0.101 local_port=41831
INFO 2.8940 data_channel.cpp:142 compute_payload_size tid=0x7e1 -- mtu=1500 overhead=74 payload_size=1408 packets=1855
INFO 2.9542 data_channel.cpp:399 configure_socket tid=0x7e1 -- (done) DataChannel configure_socket socket_fd=51 local_ip=192.168.0.101.
INFO 2.9557 data_channel.cpp:559 ReceiverMemoryDescriptor tid=0x7e1 -- Using pinned host memory: host_ptr=0x332e00000 device_ptr=0x332e00000 size=0x27e000
INFO 2.9558 linux_receiver_op.cpp:150 start_receiver tid=0x7e1 -- local_ip=192.168.0.101 local_port=33698
INFO 2.9569 data_channel.cpp:142 compute_payload_size tid=0x7e1 -- mtu=1500 overhead=74 payload_size=1408 packets=1855
[info] [context.cpp:54] _______________
[info] [context.cpp:54] Vulkan Version:
[info] [context.cpp:54]  - available:  1.4.350
[info] [context.cpp:54]  - requesting: 1.2.0
[info] [context.cpp:54] ______________________
[info] [context.cpp:54] Used Instance Layers :
[info] [context.cpp:54] 
[info] [context.cpp:54] Used Instance Extensions :
[info] [context.cpp:54] VK_KHR_surface
[info] [context.cpp:54] VK_KHR_xcb_surface
[info] [context.cpp:54] VK_KHR_display
[info] [context.cpp:54] VK_EXT_display_surface_counter
[info] [context.cpp:54] VK_EXT_debug_utils
[info] [context.cpp:54] VK_KHR_external_memory_capabilities
[info] [context.cpp:54] VK_KHR_surface
[info] [context.cpp:54] VK_KHR_get_surface_capabilities2
[info] [context.cpp:54] ____________________
[info] [context.cpp:54] Compatible Devices :
[info] [context.cpp:54] 0: NVIDIA Thor
[info] [context.cpp:54] Physical devices found : 
[info] [context.cpp:54] 1
[info] [context.cpp:54] ________________________
[info] [context.cpp:54] Used Device Extensions :
[info] [context.cpp:54] VK_KHR_swapchain
[info] [context.cpp:54] VK_EXT_display_control
[info] [context.cpp:54] VK_KHR_external_memory
[info] [context.cpp:54] VK_KHR_external_memory_fd
[info] [context.cpp:54] VK_KHR_external_semaphore
[info] [context.cpp:54] VK_KHR_external_semaphore_fd
[info] [context.cpp:54] VK_KHR_push_descriptor
[info] [context.cpp:54] VK_EXT_line_rasterization
[info] [context.cpp:54] VK_KHR_sampler_ycbcr_conversion
[info] [context.cpp:54] VK_EXT_present_mode_fifo_latest_ready
[info] [context.cpp:54] 
[info] [vulkan_app.cpp:572] Using device 0: NVIDIA Thor (UUID a7c66ad26dbbab8c1a237ba6dba360)
[info] [framebuffer_sequence.cpp:150] Using surface format 'B8G8R8A8Unorm, SrgbNonlinear'
[info] [framebuffer_sequence.cpp:170] Using depth format 'D32Sfloat'
[info] [framebuffer_sequence.cpp:360] Using present mode 'Immediate'
[info] [framebuffer_sequence.cpp:150] Using surface format 'B8G8R8A8Srgb, SrgbNonlinear'
[info] [framebuffer_sequence.cpp:170] Using depth format 'D32Sfloat'
[info] [framebuffer_sequence.cpp:360] Using present mode 'Immediate'
[info] [framebuffer_sequence.cpp:360] Using present mode 'Immediate'
[info] [holoviz.cpp:2271] Input spec:
- type: color
  name: left
  opacity: 1.000000
  priority: 0
  image_format: r16g16b16a16_unorm
  views:
    - offset_x: 0
      offset_y: 0
      width: 0.5
      height: 1
- type: color
  name: right
  opacity: 1.000000
  priority: 0
  image_format: r16g16b16a16_unorm
  views:
    - offset_x: 0.5
      offset_y: 0
      width: 0.5
      height: 1

[info] [greedy_scheduler.cpp:405] Scheduler stopped: Some entities are waiting for execution, but there are no periodic or async entities to get out of the deadlock.
[info] [greedy_scheduler.cpp:435] Scheduler finished.
[info] [gxf_executor.cpp:2930] Deactivating Graph...
[info] [gxf_executor.cpp:2939] Graph execution finished.
[info] [gxf_executor.cpp:601] Destroying context
root@jetson-agx-thor-devkit:/opt/nvidia/hololink#
```