### PR TITLE
Update onnxruntime to support both GCC 16 and 15

### DIFF
--- a/recipes-devtools/onnxruntime/onnxruntime_1.24.2.bb
+++ b/recipes-devtools/onnxruntime/onnxruntime_1.24.2.bb
@@ -118,27 +118,6 @@ FILES:${PN}-dev = " \
 FILES:python3-${PN} = "${PYTHON_SITEPACKAGES_DIR}"
 RDEPENDS:python3-${PN} = "${PN}"
 
-PACKAGECONFIG ?= "python"
-PACKAGECONFIG[python] = ",,python3-numpy-native,python3-coloredlogs python3-flatbuffers python3-numpy python3-protobuf python3-sympy"
-
-do_configure() {
-    cmake_do_configure
-}
-
-do_compile() {
-    cmake_do_compile
-    if "${@bb.utils.contains('PACKAGECONFIG', 'python', 'true', 'false', d)}"; then
-        setuptools3_do_compile
-    fi
-}
-
-do_install() {
-    cmake_do_install
-    if "${@bb.utils.contains('PACKAGECONFIG', 'python', 'true', 'false', d)}"; then
-        setuptools3_do_install
-    fi
-}
-
 INSANE_SKIP:${PN} = "buildpaths dev-so"
 INSANE_SKIP:python3-${PN} = "buildpaths"
 INSANE_SKIP:${PN}-dev = "buildpaths"

--- a/recipes-devtools/onnxruntime/onnxruntime_1.24.2.bb
+++ b/recipes-devtools/onnxruntime/onnxruntime_1.24.2.bb
@@ -76,7 +76,12 @@ EXTRA_OECMAKE = " \
 # instead of building ONNX from source or finding the shared system onnx.
 OECMAKE_EXTRA_ROOT_PATH = "${RECIPE_SYSROOT}${prefix}/onnx-ort"
 
-OECMAKE_CXX_FLAGS:append = " -Wno-array-bounds -Wno-deprecated-declarations -Wno-unused-variable -Wno-template-id-cdtor -Wno-range-loop-construct -Wno-maybe-uninitialized -Wno-error=cpp -Wno-error=uninitialized -Wno-error=sfinae-incomplete -Wno-error=unused-but-set-parameter"
+OECMAKE_CXX_FLAGS:append = " -Wno-array-bounds -Wno-deprecated-declarations -Wno-unused-variable -Wno-template-id-cdtor -Wno-range-loop-construct -Wno-maybe-uninitialized -Wno-error=cpp -Wno-error=uninitialized -Wno-error=unused-but-set-parameter"
+# -Wsfinae-incomplete was introduced in GCC 16. On older GCC the -Wno-error=
+# form is rejected outright ("cc1plus: error: no option '-Wsfinae-incomplete'"),
+# which breaks even the CMake compiler ABI test in do_configure. Only pass it
+# where the compiler actually knows the option.
+OECMAKE_CXX_FLAGS:append = "${@' -Wno-error=sfinae-incomplete' if ((d.getVar('GCCVERSION') or '').split('.')[0] or '0').isdigit() and int((d.getVar('GCCVERSION') or '0').split('.')[0]) >= 16 else ''}"
 OECMAKE_SOURCEPATH = "${S}/cmake"
 
 PACKAGECONFIG ?= "python"


### PR DESCRIPTION
This fixes #199 

- **Device:** `jetson-agx-thor-devkit` (aarch64, NVIDIA Thor)

### Environment

| Component | Version |
|---|---|
| Python | 3.14.6 |
| NumPy | 2.5.0 |
| PyTorch | 2.11.0a0 (CUDA available, CUDA 13.2) |
| ONNX | 1.20.1 |
| ONNX Runtime | 1.24.2 |
| onnxscript | 0.7.0 |
| onnx_ir | 0.2.1 |
| ml_dtypes | 0.5.4 |
| ORT providers | TensorRT, CUDA, CPU |


### Results

All stages passed using the modern onnxscript-based (`dynamo=True`) exporter,
opset 18 / IR v10.

| Stage | Result | Max abs diff |
|---|---|---|
| PyTorch CPU inference | OK | — |
| PyTorch GPU inference (vs CPU) | MATCH | `2.98e-08` |
| ONNX export (dynamo=True) | SUCCESS | — |
| `onnx.checker.check_model` | PASSED | — |
| ONNX Runtime CPU vs PyTorch | MATCH | `2.98e-08` |
| ONNX Runtime CUDA vs PyTorch | MATCH | `2.98e-08` |



[test_ml_stack.py](https://github.com/user-attachments/files/29860246/test_ml_stack.py)



