### PR TITLE
Update deepstream-7.1_7.1.0-1.bb

### DIFF
--- a/recipes-devtools/deepstream/deepstream-7.1_7.1.0-1.bb
+++ b/recipes-devtools/deepstream/deepstream-7.1_7.1.0-1.bb
@@ -32,7 +32,7 @@ PACKAGECONFIG[rivermax] = ""
 PACKAGECONFIG[realsense] = ""
 
 DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-rtsp-server \
-    tensorrt-core tensorrt-plugins libnvvpi3 libcufft libcublas libnpp json-glib \
+    tensorrt-core tensorrt-plugins libnvvpi4 libcufft libcublas libnpp json-glib \
     openssl tegra-libraries-multimedia-ds tegra-libraries-multimedia yaml-cpp-070 \
     grpc protobuf tegra-libraries-nvdsseimeta libgstnvcustomhelper mosquitto jsoncpp cuda-nvrtc \
 "


### PR DESCRIPTION
Wrynose branch of meta-tegra is now JetPack 7.2 where VPI recipe is now libnvvpi4