### PR TITLE
Convert licenses to SPDX expressions

### DIFF
--- a/recipes-devtools/concurrentqueue/concurrentqueue_1.0.4.bb
+++ b/recipes-devtools/concurrentqueue/concurrentqueue_1.0.4.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "A fast multi-producer, multi-consumer lock-free concurrent queue for C++11"
 HOMEPAGE = "https://github.com/cameron314/concurrentqueue"
-LICENSE = "BSD-2-Clause & BSL-1.0"
+LICENSE = "BSD-2-Clause AND BSL-1.0"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=3e3bd5d3367ca1cdb53ff11ab44322ea"
 
 inherit cmake

--- a/recipes-devtools/deepstream/deepstream-9.1_9.1.0-1.bb
+++ b/recipes-devtools/deepstream/deepstream-9.1_9.1.0-1.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NVIDIA Deepstream SDK"
 HOMEPAGE = "https://developer.nvidia.com/deepstream-sdk"
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = " \
     file://usr/share/doc/deepstream-9.1/copyright;md5=d491e636a05accc669f7c2741540bc0f \
     file://opt/nvidia/deepstream/deepstream-9.1/LICENSE.txt;md5=675906f1fcfa7711c6b07dc356dfe550 \

--- a/recipes-devtools/nccl/nccl_2.29.7-1.bb
+++ b/recipes-devtools/nccl/nccl_2.29.7-1.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Optimized primitives for collective multi-GPU communication"
 HOMEPAGE = "https://github.com/NVIDIA/nccl"
-LICENSE = "Apache-2.0 & BSD-3-Clause"
+LICENSE = "Apache-2.0 AND BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b534c6bfd96fb19f09094709991f6788"
 
 SRC_URI = " \

--- a/recipes-devtools/nvcomp/nvcomp_5.2.0.10.bb
+++ b/recipes-devtools/nvcomp/nvcomp_5.2.0.10.bb
@@ -1,6 +1,6 @@
 SUMMARY = "nvCOMP library provides fast lossless data compression and decompression using a GPU"
 HOMEPAGE = "https://docs.nvidia.com/cuda/nvcomp"
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://nvcomp-linux-sbsa-${PV}_cuda13-archive/LICENSE;md5=85649c377f72fda614b170fb9e1216f3"
 
 COMPATIBLE_MACHINE = "(cuda)"

--- a/recipes-devtools/python/python3-cuda_13.2.0.bb
+++ b/recipes-devtools/python/python3-cuda_13.2.0.bb
@@ -1,6 +1,6 @@
 SUMMARY = "CUDA Python Low-level Bindings"
 HOMEPAGE = "https://nvidia.github.io/cuda-python"
-LICENSE = "Apache-2.0 & Proprietary"
+LICENSE = "Apache-2.0 AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = " \
     file://LICENSE.md;md5=5028fedd819277227c4246007f1c0190 \
     file://cuda_core/LICENSE;md5=2ee41112a44fe7014dce33e26468ba93 \

--- a/recipes-devtools/vpi/vpi4-samples_4.1.3.bb
+++ b/recipes-devtools/vpi/vpi4-samples_4.1.3.bb
@@ -1,6 +1,6 @@
 SUMMARY = "NVIDIA VPI command-line sample applications"
 HOMEPAGE = "https://developer.nvidia.com/embedded/vpi"
-LICENSE = "BSD-3-Clause & Proprietary"
+LICENSE = "BSD-3-Clause AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://01-convolve_2d/main.cpp;endline=27;md5=ad6efe6d8b43b8bceef6d97c7b79193f \
                     file://assets/LICENSE;md5=6b5f633fc3acaabf21035790a05b1c71"
 


### PR DESCRIPTION
openembedded-core has enabled more strict license checks recently. This PR fix the warnings caused by improper SPDX strings.
Related changes in https://github.com/OE4T/meta-tegra/pull/2309.