### PR TITLE
python3-cuda: Pin setuptools-scm versions for split sub-packages

### DIFF
--- a/recipes-devtools/python/python3-cuda_13.2.0.bb
+++ b/recipes-devtools/python/python3-cuda_13.2.0.bb
@@ -26,6 +26,19 @@ B = "${S}"
 export CUDA_HOME = "${STAGING_DIR_HOST}/usr/local/cuda-${CUDA_VERSION}"
 export CUDA_PYTHON_PARALLEL_LEVEL = "${@oe.utils.cpu_count()}"
 CUDA_PYTHON_PARALLEL_LEVEL[vardepvalue] = "1"
+
+# The cuda-python monorepo versions each sub-package independently via
+# setuptools-scm using component-specific tags (cuda-pathfinder-vX.Y.Z,
+# cuda-core-vX.Y.Z, ...). Only the umbrella v${PV} tag is fetched (shallow) and
+# the applied patch dirties the worktree, so setuptools-scm cannot resolve the
+# per-component versions and falls back to a bogus "0.1.dev1", which breaks the
+# cuda-bindings 'cuda-pathfinder~=1.1' and cuda-core 'cuda-pathfinder>=1.4.1'
+# build requirements. Pin each explicitly to the versions at this SRCREV.
+export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CUDA_PATHFINDER = "1.4.2"
+export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CUDA_BINDINGS = "${PV}"
+export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CUDA_CORE = "0.7.0"
+export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CUDA_PYTHON = "${PV}"
+
 CXXFLAGS += "-I${RECIPE_SYSROOT}/usr/local/cuda-${CUDA_VERSION}/include"
 CFLAGS += "-I${RECIPE_SYSROOT}/usr/local/cuda-${CUDA_VERSION}/include"
 


### PR DESCRIPTION
The cuda-python monorepo versions cuda_pathfinder, cuda_bindings, cuda_core and cuda_python independently via setuptools-scm using component-specific tags. Only the umbrella v13.2.0 tag is fetched and the OE cross-build patch dirties the worktree, so setuptools-scm falls back to "0.1.dev1" for the components lacking a reachable tag. do_compile then fails building cuda_core:

  cuda-bindings==13.* -> cuda-pathfinder~=1.1
    wanted: ~=1.1
    found: 0.1.dev1+g06e60656c.d20260310

Pin each component with SETUPTOOLS_SCM_PRETEND_VERSION_FOR_* to the versions at this SRCREV, which also makes the build reproducible.